### PR TITLE
Tuple always encodes `Int8` value to 0

### DIFF
--- a/Sources/FoundationDB/TupleConvertible.swift
+++ b/Sources/FoundationDB/TupleConvertible.swift
@@ -231,6 +231,16 @@ extension Int8: TupleConvertible {
 	public struct FoundationDBTupleAdapter: TupleAdapter {
 		public typealias ValueType = Int8
 		public static let typeCodes = integerTypeCodes()
+
+        public static func write(value: Int8, into buffer: inout Data) {
+            Int16.FoundationDBTupleAdapter.write(value: Int16(value), into: &buffer)
+        }
+        public static func read(from buffer: Data, at offset: Int) throws -> ValueType {
+            guard let value = Int8(exactly: try Int16.FoundationDBTupleAdapter.read(from: buffer, at: offset)) else {
+                throw TupleDecodingError.integerOverflow
+            }
+            return value
+        }
 	}
 }
 

--- a/Tests/FoundationDBTests/TupleTests.swift
+++ b/Tests/FoundationDBTests/TupleTests.swift
@@ -523,4 +523,11 @@ class TupleTests: XCTestCase {
 	func testCompareTuplesWithPrefixAsSecondReturnsFalse() {
 		XCTAssertFalse(Tuple("Value2") < Tuple("Value"))
 	}
+
+    func testTupleInt8Conversion() {
+        let value = Int8(-100)
+        let tuple = Tuple(value)
+
+        XCTAssertEqual(value, try tuple.read(at: 0))
+    }
 }


### PR DESCRIPTION
This line always return 0.
https://github.com/FoundationDB/fdb-swift-bindings/blob/8c0d9ae835752d0d0408d12c775bd72fec62e014/Sources/FoundationDB/TupleConvertible.swift#L133

Probably Swift implicitly tries to convert `0xFF` to `Int8` and fails.
Debugger shows this error: 

> integer literal '255' overflows when stored into 'Int8'

I fixed it with `Int16` as backend. May be there is a more elegant solution.