### PR TITLE
Fix `DatabaseValue.hasPrefix`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/FoundationDB/fdb-swift-c-packaging",
         "state": {
           "branch": "master",
-          "revision": "70264741f8a9b6c8b30746611658f82e78aca8a2",
+          "revision": "46a7f29471ae73aa8f21fb1839703fc62420da23",
           "version": null
         }
       },
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio",
         "state": {
           "branch": null,
-          "revision": "cf08e673dc41dc63d34065234c8fc432e8d334c4",
-          "version": "1.9.2"
+          "revision": "8da5c5a4e6c5084c296b9f39dc54f00be146e0fa",
+          "version": "1.14.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(
@@ -12,7 +12,7 @@ let package = Package(
     .package(url: "https://github.com/FoundationDB/fdb-swift-c-packaging", .branch("master"))
   ],
   targets: [
-    .target(name: "FoundationDB", dependencies: ["NIO", "CFoundationDB"]),
+    .target(name: "FoundationDB", dependencies: [.product(name: "NIO", package: "swift-nio"), "CFoundationDB"]),
     .target(name: "CFoundationDB"),
     .target(name: "FoundationDBBindingTest", dependencies: ["FoundationDB"]),
     .target(name: "FoundationDBBindingTestRunner", dependencies: ["FoundationDBBindingTest"]),

--- a/Sources/FoundationDB/DatabaseValue.swift
+++ b/Sources/FoundationDB/DatabaseValue.swift
@@ -46,7 +46,7 @@ public struct DatabaseValue: Equatable, Hashable, Comparable, ExpressibleByStrin
 	}
 	
 	public init(bytes: [UInt8]) {
-		self.init(Data(bytes: bytes))
+		self.init(Data(bytes))
 	}
 	
 	
@@ -56,7 +56,7 @@ public struct DatabaseValue: Equatable, Hashable, Comparable, ExpressibleByStrin
 	- parameter string:		The string to put in the tuple.
 	*/
 	public init(string: String) {
-		self.init(Data(bytes: Array(string.utf8)))
+		self.init(Data(Array(string.utf8)))
 	}
 	
 	/**

--- a/Sources/FoundationDB/DatabaseValue.swift
+++ b/Sources/FoundationDB/DatabaseValue.swift
@@ -97,11 +97,11 @@ public struct DatabaseValue: Equatable, Hashable, Comparable, ExpressibleByStrin
 	prefix.
 	*/
 	public func hasPrefix(_ prefix: DatabaseValue) -> Bool {
-		if prefix.data.count > self.data.count { return false }
-		for index in 0..<prefix.data.count {
-			if self.data[index] != prefix.data[index] { return false }
-		}
-		return true
+        if prefix.data.count > self.data.count { return false }
+        for index in 0..<prefix.data.count {
+            if data[data.index(data.startIndex, offsetBy: index)] != prefix.data[prefix.data.index(prefix.data.startIndex, offsetBy: index)] { return false }
+        }
+        return true
 	}
 	
 	/**

--- a/Sources/FoundationDB/InMemoryTransaction.swift
+++ b/Sources/FoundationDB/InMemoryTransaction.swift
@@ -100,7 +100,7 @@ public final class InMemoryTransaction: Transaction {
 	- returns:					The first key matching this selector.
 	*/
 	public func findKey(selector: KeySelector, snapshot: Bool) -> EventLoopFuture<DatabaseValue?> {
-		let keys = self.database.keys(from: DatabaseValue(Data(bytes: [0x00])), to: DatabaseValue(Data(bytes: [0xFF])))
+		let keys = self.database.keys(from: DatabaseValue(Data([0x00])), to: DatabaseValue(Data([0xFF])))
 		let index = self.keyMatching(selector: selector, from: keys)
 		if index >= keys.startIndex && index < keys.endIndex {
 			return eventLoop.newSucceededFuture(result: keys[index])
@@ -120,7 +120,7 @@ public final class InMemoryTransaction: Transaction {
 	will return the end index of the list.
 	*/
 	private func keyMatching(selector: KeySelector, from keys: [DatabaseValue]) -> Int {
-		var index = keys.index { selector.orEqual == 0 ? $0 >= selector.anchor : $0 > selector.anchor } ?? keys.endIndex
+		var index = keys.firstIndex { selector.orEqual == 0 ? $0 >= selector.anchor : $0 > selector.anchor } ?? keys.endIndex
 		index += Int(selector.offset) - 1
 		index = min(max(index, keys.startIndex - 1), keys.endIndex)
 		return index
@@ -153,7 +153,7 @@ public final class InMemoryTransaction: Transaction {
 	*/
 	public func readSelectors(from start: KeySelector, to end: KeySelector, limit: Int?, mode: StreamingMode, snapshot: Bool, reverse: Bool) ->	EventLoopFuture<ResultSet> {
 		return eventLoop.submit {
-			let allKeys = self.database.keys(from: DatabaseValue(Data(bytes: [0x00])), to: DatabaseValue(Data(bytes: [0xFF])))
+			let allKeys = self.database.keys(from: DatabaseValue(Data([0x00])), to: DatabaseValue(Data([0xFF])))
 			
 			var startIndex = self.keyMatching(selector: start, from: allKeys)
 			startIndex = max(startIndex, allKeys.startIndex)
@@ -376,7 +376,7 @@ public final class InMemoryTransaction: Transaction {
 			bytes.insert(UInt8(versionCopy & 0xFF), at: 0)
 			versionCopy = versionCopy >> 8
 		}
-		promise.succeed(result: DatabaseValue(Data(bytes: bytes)))
+		promise.succeed(result: DatabaseValue(Data(bytes)))
 	}
 	
 	/**

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -261,9 +261,9 @@ public struct Tuple: Equatable, Hashable, Comparable {
 	/**
 		This method gets the hash code for this tuple.
 		*/
-	public var hashValue: Int {
-		return data.hashValue
-	}
+    public func hash(into hasher: inout Hasher) {
+        data.hash(into: &hasher)
+    }
 	
 	/**
 		This method increments the last entry in the tuple.

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -251,11 +251,11 @@ public struct Tuple: Equatable, Hashable, Comparable {
 								prefix.
 		*/
 	public func hasPrefix(_ prefix: Tuple) -> Bool {
-		if prefix.data.count > self.data.count { return false }
-		for index in 0..<prefix.data.count {
-			if self.data[index] != prefix.data[index] { return false }
-		}
-		return true
+        if prefix.data.count > self.data.count { return false }
+        for index in 0..<prefix.data.count {
+            if data[data.index(data.startIndex, offsetBy: index)] != prefix.data[prefix.data.index(prefix.data.startIndex, offsetBy: index)] { return false }
+        }
+        return true
 	}
 	
 	/**

--- a/Sources/FoundationDB/TupleConvertible.swift
+++ b/Sources/FoundationDB/TupleConvertible.swift
@@ -135,7 +135,7 @@ extension TupleAdapter where ValueType: FixedWidthInteger {
 		}
 		let blankByte: UInt8 = (int < 0 ? 0xFF : 0x00)
 		let sign = (int < 0 ? -1 : 1)
-		let firstRealByte = bytes.index { $0 != blankByte } ?? bytes.endIndex
+		let firstRealByte = bytes.firstIndex { $0 != blankByte } ?? bytes.endIndex
 		buffer.append(UInt8(20 + sign * (bytes.count - firstRealByte)))
 		#if os(OSX)
 		buffer.append(contentsOf: bytes[firstRealByte..<bytes.count])
@@ -313,7 +313,7 @@ extension Data: TupleConvertible {
 		}
 		
 		public static func read(from buffer: Data, at offset: Int) -> Data {
-			return Data(bytes: readBytes(from: buffer, offset: offset + 1))
+			return Data(readBytes(from: buffer, offset: offset + 1))
 		}
 	}
 }

--- a/Sources/FoundationDBBindingTest/StackMachine.swift
+++ b/Sources/FoundationDBBindingTest/StackMachine.swift
@@ -868,7 +868,7 @@ public final class StackMachine {
 					UInt8((bits >> 16) & 0xFF),
 					UInt8((bits >> 8) & 0xFF),
 					UInt8(bits & 0xFF),
-				])
+				] as [UInt8])
 				self.push(value: data)
 			}
 		case .startThread:

--- a/Tests/FoundationDBTests/DatabaseValueTests.swift
+++ b/Tests/FoundationDBTests/DatabaseValueTests.swift
@@ -34,6 +34,7 @@ class DatabaseValueTests: XCTestCase {
 			("testHasPrefixWithPrefixValueIsTrue", testHasPrefixWithPrefixValueIsTrue),
 			("testHasPrefixWithSiblingKeyIsFalse", testHasPrefixWithSiblingKeyIsFalse),
 			("testHasPrefixWithChildKeyIsFalse", testHasPrefixWithChildKeyIsFalse),
+            ("testHasPrefixWithSubrangePrefixValueIsTrue", testHasPrefixWithSubrangePrefixValueIsTrue),
 			("testIncrementIncrementsLastByte", testIncrementIncrementsLastByte),
 			("testIncrementCanCarryIntoEarlierBytes", testIncrementCanCarryIntoEarlierBytes),
 			("testIncrementWithMaxValueWrapsToZero", testIncrementWithMaxValueWrapsToZero),
@@ -96,6 +97,12 @@ class DatabaseValueTests: XCTestCase {
 		let key2 = DatabaseValue(bytes: [1,2,3,4,5])
 		XCTAssertFalse(key1.hasPrefix(key2))
 	}
+
+    func testHasPrefixWithSubrangePrefixValueIsTrue() {
+        let key1 = DatabaseValue(Data([0,1,2,3,4])[1...])
+        let key2 = DatabaseValue(bytes: [1,2,3,4,5])
+        XCTAssertTrue(key2.hasPrefix(key1))
+    }
 	
 	func testIncrementIncrementsLastByte() {
 		var key = DatabaseValue(bytes: [1,2,3,4])

--- a/Tests/FoundationDBTests/TupleTests.swift
+++ b/Tests/FoundationDBTests/TupleTests.swift
@@ -59,6 +59,7 @@ class TupleTests: XCTestCase {
 			("testHasPrefixWithPrefixTupleIsTrue", testHasPrefixWithPrefixTupleIsTrue),
 			("testHasPrefixWithSiblingKeyIsFalse", testHasPrefixWithSiblingKeyIsFalse),
 			("testHasPrefixWithChildKeyIsFalse", testHasPrefixWithChildKeyIsFalse),
+            ("testHasPrefixReadRangeAndEvaluateHasPrefixIsTrue", testHasPrefixReadRangeAndEvaluateHasPrefixIsTrue),
 			("testIncrementLastEntryWithIntegerEntryIncrementsValue", testIncrementLastEntryWithIntegerEntryIncrementsValue),
 			("testIncrementLastEntryWithIntegerWithCarryCarriesIncrement", testIncrementLastEntryWithIntegerWithCarryCarriesIncrement),
 			("testIncrementLastEntryWithIntegerOverflowResetsToZero", testIncrementLastEntryWithIntegerOverflowResetsToZero),
@@ -410,6 +411,16 @@ class TupleTests: XCTestCase {
 		let key2 = Tuple("Test", "Key", 2)
 		XCTAssertFalse(key1.hasPrefix(key2))
 	}
+
+    func testHasPrefixReadRangeAndEvaluateHasPrefixIsTrue() {
+        do {
+            let key1 = try Tuple("Prefix", "Test", "Key").read(range: 1..<3)
+            let key2 = Tuple("Test", "Keys")
+            XCTAssertFalse(key2.hasPrefix(key1))
+        } catch let e {
+            XCTFail(e.localizedDescription)
+        }
+    }
 	
 	func testIncrementLastEntryWithIntegerEntryIncrementsValue() {
 		var key = Tuple("Test", "Key", 5)

--- a/Tests/FoundationDBTests/TupleTests.swift
+++ b/Tests/FoundationDBTests/TupleTests.swift
@@ -415,8 +415,8 @@ class TupleTests: XCTestCase {
     func testHasPrefixReadRangeAndEvaluateHasPrefixIsTrue() {
         do {
             let key1 = try Tuple("Prefix", "Test", "Key").read(range: 1..<3)
-            let key2 = Tuple("Test", "Keys")
-            XCTAssertFalse(key2.hasPrefix(key1))
+            let key2 = Tuple("Test", "Key")
+            XCTAssertTrue(key2.hasPrefix(key1))
         } catch let e {
             XCTFail(e.localizedDescription)
         }


### PR DESCRIPTION
`DatabaseValue.hasPrefix` has unsafe access to data.
`Tuple.hasPrefix` too.