### PR TITLE
Remove FoundationDB-Swift-Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,5 +88,3 @@ install(TARGETS FoundationDB-Swift stacktester_swift
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
 )
-
-add_test(NAME FoundationDB-Swift-Tests COMMAND FoundationDB-Swift-Tests)


### PR DESCRIPTION
CMake doesn't need to add that as test. We are testing using Github Actions here already.