### PR TITLE
Make TupleElement a non-exhaustive enum

### DIFF
--- a/Sources/FoundationDB/Subspace.swift
+++ b/Sources/FoundationDB/Subspace.swift
@@ -167,12 +167,11 @@ public struct Subspace: Sendable {
     ///
     /// This operation is the inverse of `encode(_:)`. It removes the subspace prefix
     /// and decodes the remaining bytes as a tuple.
-    public func decode(_ key: FDB.Bytes) throws -> Tuple {
+    public func decode<B: Collection<UInt8>>(_ key: B) throws -> Tuple {
         guard key.starts(with: prefix) else {
             throw TupleError.invalidDecoding("Key does not match subspace prefix")
         }
-        let tupleBytes = Array(key.dropFirst(prefix.count))
-        return try Tuple.decode(from: tupleBytes)
+        return try Tuple.decode(from: key.dropFirst(prefix.count))
     }
 
     /// Check if a key belongs to this subspace

--- a/Sources/FoundationDB/Subspace.swift
+++ b/Sources/FoundationDB/Subspace.swift
@@ -1,0 +1,414 @@
+/*
+ * Subspace.swift
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2016-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// FoundationDB subspace for key management
+///
+/// A Subspace represents a well-defined region of keyspace in FoundationDB.
+/// It provides methods for encoding keys with a prefix and decoding them back.
+///
+/// Subspaces are used to partition the key space into logical regions, similar to
+/// tables in a relational database. They ensure that keys from different regions
+/// don't collide by prepending a unique prefix to all keys.
+///
+/// ## Example Usage
+///
+/// ```swift
+/// // Create a root subspace with tuple-encoded prefix
+/// let userSpace = Subspace(prefix: Tuple("users").encode())
+///
+/// // Create nested subspaces
+/// let activeUsers = userSpace.subspace("active")
+///
+/// // Encode keys with the subspace prefix
+/// let key = userSpace.encode(Tuple(12345, "alice"))
+///
+/// // Decode keys to get the original tuple
+/// let tuple = try userSpace.decode(key)
+/// ```
+public struct Subspace: Sendable {
+    /// The binary prefix for this subspace
+    public let prefix: FDB.Bytes
+
+    // MARK: - Initialization
+
+    /// Create a subspace with a binary prefix
+    ///
+    /// In production code, prefixes should typically be obtained from the Directory Layer,
+    /// which manages namespaces and prevents collisions. This initializer is provided for:
+    /// - Testing and development
+    /// - Integration with existing systems that manage prefixes externally
+    /// - Special system prefixes (e.g., DirectoryLayer internal keys)
+    ///
+    /// - Warning: Subspace is primarily designed for tuple-encoded prefixes.
+    ///   Using raw binary prefixes may result in range queries that do not
+    ///   include all keys within the subspace if the prefix ends with 0xFF bytes.
+    ///
+    ///   **Known Limitation**: The `range()` method uses `prefix + [0xFF]` as
+    ///   the exclusive upper bound. This means keys like `[prefix, 0xFF, 0x00]`
+    ///   will fall outside the returned range because they are lexicographically
+    ///   greater than `[prefix, 0xFF]`.
+    ///
+    ///   Example:
+    ///   ```swift
+    ///   let subspace = Subspace(prefix: [0x01, 0xFF])
+    ///   let (begin, end) = subspace.range()
+    ///   // begin = [0x01, 0xFF, 0x00]
+    ///   // end   = [0x01, 0xFF, 0xFF]
+    ///
+    ///   // Keys like [0x01, 0xFF, 0xFF, 0x00] will NOT be included
+    ///   // because they are > [0x01, 0xFF, 0xFF] in lexicographical order
+    ///   ```
+    ///
+    /// - Important: For tuple-encoded data (created via `subspace(_:)`),
+    ///   this limitation does not apply because tuple type codes never include 0xFF.
+    ///
+    /// - Note: This behavior matches the official Java, C++, Python, and Go
+    ///   implementations. A subspace formed with a raw byte string as a prefix
+    ///   is not fully compatible with the tuple layer, and keys stored within it
+    ///   cannot be decoded as tuples unless they were originally tuple-encoded.
+    ///
+    /// - Parameter prefix: The binary prefix
+    ///
+    /// - See also: https://apple.github.io/foundationdb/developer-guide.html#subspaces
+    public init(prefix: FDB.Bytes) {
+        self.prefix = prefix
+    }
+
+    // MARK: - Subspace Creation
+
+    /// Create a nested subspace by appending tuple elements
+    /// - Parameter elements: Tuple elements to append
+    /// - Returns: A new subspace with the extended prefix
+    public func subspace(_ elements: [TupleElementConvertible]) -> Subspace {
+        Subspace(prefix: self.prefix + Tuple(elements).encode())
+    }
+
+    /// Create a nested subspace by appending tuple elements
+    /// - Parameter elements: Tuple elements to append
+    /// - Returns: A new subspace with the extended prefix
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let users = Subspace(prefix: Tuple("users").encode())
+    /// let activeUsers = users.subspace("active")  // prefix = users + "active"
+    /// let userById = activeUsers.subspace(12345)  // prefix = users + "active" + 12345
+    /// ```
+    public func subspace(_ elements: TupleElementConvertible...) -> Subspace {
+        self.subspace(elements)
+    }
+
+    /// Create a nested subspace using subscript syntax
+    /// - Parameter elements: Tuple elements to append
+    /// - Returns: A new subspace with the extended prefix
+    ///
+    /// This provides convenient subscript access for creating nested subspaces,
+    /// matching Python's `__getitem__` pattern.
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let root = Subspace(prefix: Tuple("app").encode())
+    /// let users = root["users"]
+    /// let activeUsers = root["users"]["active"]
+    /// // Equivalent to: root.subspace("users").subspace("active")
+    /// ```
+    public subscript(index: TupleElementConvertible...) -> Subspace {
+        self.subspace(index)
+    }
+
+    // MARK: - Key Encoding/Decoding
+
+    /// Encode a tuple into a key with this subspace's prefix
+    /// - Parameter tuple: The tuple to encode
+    /// - Returns: The encoded key with prefix
+    ///
+    /// The returned key will have the format: `[prefix][encoded tuple]`
+    public func encode(_ tuple: Tuple) -> FDB.Bytes {
+        return prefix + tuple.encode()
+    }
+
+    /// Encode additional tuple elements into a key with this subspace's prefix
+    /// - Parameter elements: The tuple elements to encode
+    /// - Returns: The encoded key with prefix
+    ///
+    /// The returned key will have the format: `[prefix][encoded elements...]`
+    public func encode(_ elements: TupleElementConvertible...) -> FDB.Bytes {
+        if elements.isEmpty {
+            prefix
+        } else {
+            subspace(elements).prefix
+        }
+    }
+
+    /// Decode a key into a tuple, removing this subspace's prefix
+    /// - Parameter key: The key to decode
+    /// - Returns: The decoded tuple
+    /// - Throws: `TupleError.invalidDecoding` if the key doesn't start with this prefix
+    ///
+    /// This operation is the inverse of `encode(_:)`. It removes the subspace prefix
+    /// and decodes the remaining bytes as a tuple.
+    public func decode(_ key: FDB.Bytes) throws -> Tuple {
+        guard key.starts(with: prefix) else {
+            throw TupleError.invalidDecoding("Key does not match subspace prefix")
+        }
+        let tupleBytes = Array(key.dropFirst(prefix.count))
+        return try Tuple.decode(from: tupleBytes)
+    }
+
+    /// Check if a key belongs to this subspace
+    /// - Parameter key: The key to check
+    /// - Returns: true if the key starts with this subspace's prefix
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let userSpace = Subspace(prefix: Tuple("users").encode())
+    /// let key = userSpace.encode(12345)
+    /// print(userSpace.contains(key))  // true
+    ///
+    /// let otherKey = Subspace(prefix: Tuple("posts").encode()).encode(1)
+    /// print(userSpace.contains(otherKey))  // false
+    /// ```
+    public func contains(_ key: FDB.Bytes) -> Bool {
+        return key.starts(with: prefix)
+    }
+
+    // MARK: - Range Operations
+
+    /// Get the range for scanning all keys in this subspace
+    ///
+    /// The range is defined as `[prefix + 0x00, prefix + 0xFF)`, which:
+    /// - Includes all keys that start with the subspace prefix and have additional bytes
+    /// - Does NOT include the bare prefix itself (if it exists as a key)
+    ///
+    /// ## Important Limitation with Raw Binary Prefixes
+    ///
+    /// - Warning: If this subspace was created with a raw binary prefix using
+    ///   `init(prefix:)`, keys that begin with `[prefix, 0xFF, ...]` may fall
+    ///   outside the returned range.
+    ///
+    ///   This is because `prefix + [0xFF]` is used as the exclusive upper bound,
+    ///   and any key starting with `[prefix, 0xFF]` followed by additional bytes
+    ///   will be lexicographically greater than `[prefix, 0xFF]`.
+    ///
+    ///   Example of keys that will be **excluded**:
+    ///   ```swift
+    ///   let subspace = Subspace(prefix: [0x01, 0xFF])
+    ///   let (begin, end) = subspace.range()
+    ///   // begin = [0x01, 0xFF, 0x00]
+    ///   // end   = [0x01, 0xFF, 0xFF]
+    ///
+    ///   // These keys are OUTSIDE the range:
+    ///   // [0x01, 0xFF, 0xFF]          (equal to end, excluded)
+    ///   // [0x01, 0xFF, 0xFF, 0x00]    (> end)
+    ///   // [0x01, 0xFF, 0xFF, 0xFF]    (> end)
+    ///   ```
+    ///
+    /// ## Why This Works for Tuple-Encoded Data
+    ///
+    /// For tuple-encoded data (created via `init(rootPrefix:)` or `subspace(_:)`),
+    /// this limitation does not apply because:
+    /// - Tuple type codes range from 0x00 to 0x33
+    /// - 0xFF is not a valid tuple type code
+    /// - Therefore, no tuple-encoded key will ever have 0xFF immediately after the prefix
+    ///
+    /// This makes `prefix + [0xFF]` a safe exclusive upper bound for all
+    /// tuple-encoded keys within the subspace.
+    ///
+    /// ## Cross-Language Compatibility
+    ///
+    /// This implementation matches the canonical behavior of all official bindings:
+    /// - Java: `new Range(prefix + 0x00, prefix + 0xFF)`
+    /// - Python: `slice(prefix + b"\x00", prefix + b"\xff")`
+    /// - Go: `(prefix + 0x00, prefix + 0xFF)`
+    /// - C++: `(prefix + 0x00, prefix + 0xFF)`
+    ///
+    /// The limitation with raw binary prefixes exists in all these implementations.
+    ///
+    /// ## Recommended Usage
+    ///
+    /// - ✅ **Recommended**: Use with tuple-encoded data via `init(rootPrefix:)` or `subspace(_:)`
+    /// - ⚠️ **Caution**: Avoid raw binary prefixes ending in 0xFF bytes
+    /// - 💡 **Alternative**: For raw binary prefix ranges, consider using a strinc-based
+    ///   method (to be provided in future versions)
+    ///
+    /// ## Example (Tuple-Encoded Data)
+    ///
+    /// ```swift
+    /// let userSpace = Subspace(prefix: Tuple("users").encode())
+    /// let (begin, end) = userSpace.range()
+    ///
+    /// // Scan all user keys (safe - tuple-encoded)
+    /// let sequence = transaction.getRange(
+    ///     beginKey: begin,
+    ///     endKey: end
+    /// )
+    /// for try await (key, value) in sequence {
+    ///     // Process each user key-value pair
+    /// }
+    /// ```
+    ///
+    /// - Returns: A tuple of (begin, end) keys for range operations
+    ///
+    /// - SeeAlso: `init(prefix:)` for warnings about raw binary prefixes
+    public func range() -> (begin: FDB.Bytes, end: FDB.Bytes) {
+        let begin = prefix + [0x00]
+        let end = prefix + [0xFF]
+        return (begin, end)
+    }
+
+    /// Get a range with specific start and end tuples
+    /// - Parameters:
+    ///   - start: Start tuple (inclusive)
+    ///   - end: End tuple (exclusive)
+    /// - Returns: A tuple of (begin, end) keys
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let userSpace = Subspace(prefix: Tuple("users").encode())
+    /// // Scan users with IDs from 1000 to 2000
+    /// let (begin, end) = userSpace.range(from: Tuple(1000), to: Tuple(2000))
+    /// ```
+    public func range(from start: Tuple, to end: Tuple) -> (begin: FDB.Bytes, end: FDB.Bytes) {
+        return (encode(start), encode(end))
+    }
+}
+
+// MARK: - Equatable & Hashable
+// Compiler-synthesized implementations
+
+extension Subspace: Equatable {}
+extension Subspace: Hashable {}
+
+// MARK: - CustomStringConvertible
+
+extension Subspace: CustomStringConvertible {
+    public var description: String {
+        let hexString = prefix.map { String(format: "%02x", $0) }.joined()
+        return "Subspace(prefix: \(hexString))"
+    }
+}
+
+// MARK: - SubspaceError
+
+/// Errors that can occur in Subspace operations
+public struct SubspaceError: Error {
+    /// Error code identifying the type of error
+    public let code: Code
+
+    /// Human-readable error message
+    public let message: String
+
+    /// Error codes for Subspace operations
+    public enum Code: Sendable {
+        /// The key cannot be incremented because it contains only 0xFF bytes
+        case cannotIncrementKey
+    }
+
+    /// Creates a new SubspaceError
+    /// - Parameters:
+    ///   - code: The error code
+    ///   - message: Human-readable error message
+    public init(code: Code, message: String) {
+        self.code = code
+        self.message = message
+    }
+
+    /// The key cannot be incremented because it contains only 0xFF bytes
+    public static func cannotIncrementKey(_ message: String) -> SubspaceError {
+        return SubspaceError(code: .cannotIncrementKey, message: message)
+    }
+}
+
+// MARK: - Subspace Prefix Range Extension
+
+extension Subspace {
+    /// Get range for raw binary prefix (includes prefix itself)
+    ///
+    /// This method is useful when working with raw binary prefixes that were not
+    /// tuple-encoded. It uses the strinc algorithm to compute the exclusive upper bound,
+    /// which ensures that ALL keys starting with the prefix are included in the range.
+    ///
+    /// Unlike `range()`, which uses `prefix + [0xFF]` as the upper bound, this method
+    /// uses `strinc(prefix)`, which correctly handles prefixes ending in 0xFF bytes.
+    ///
+    /// ## When to Use This Method
+    ///
+    /// - ✅ Use this when the subspace was created with `init(prefix:)` using raw binary data
+    /// - ✅ Use this when you need to ensure ALL keys with the prefix are included
+    /// - ✅ Use this for non-tuple-encoded keys
+    ///
+    /// ## When to Use `range()` Instead
+    ///
+    /// - ✅ Use `range()` for tuple-encoded data (via `init(rootPrefix:)` or `subspace(_:)`)
+    /// - ✅ Use `range()` for standard tuple-based data modeling
+    ///
+    /// ## Comparison
+    ///
+    /// ```swift
+    /// let subspace = Subspace(prefix: [0x01, 0xFF])
+    ///
+    /// // range() - may miss keys
+    /// let (begin1, end1) = subspace.range()
+    /// // begin1 = [0x01, 0xFF, 0x00]
+    /// // end1   = [0x01, 0xFF, 0xFF]
+    /// // Excludes: [0x01, 0xFF, 0xFF, 0x00], [0x01, 0xFF, 0xFF, 0xFF], etc.
+    ///
+    /// // prefixRange() - includes all keys
+    /// let (begin2, end2) = try subspace.prefixRange()
+    /// // begin2 = [0x01, 0xFF]
+    /// // end2   = [0x02]
+    /// // Includes: ALL keys starting with [0x01, 0xFF]
+    /// ```
+    ///
+    /// - Returns: Range from prefix (inclusive) to strinc(prefix) (exclusive)
+    /// - Throws: `SubspaceError.cannotIncrementKey` if prefix cannot be incremented
+    ///   (i.e., if the prefix is empty or contains only 0xFF bytes)
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// let subspace = Subspace(prefix: [0x01, 0xFF])
+    ///
+    /// do {
+    ///     let (begin, end) = try subspace.prefixRange()
+    ///     // begin = [0x01, 0xFF]
+    ///     // end   = [0x02]
+    ///
+    ///     let sequence = transaction.getRange(beginKey: begin, endKey: end)
+    ///     for try await (key, value) in sequence {
+    ///         // Process all keys starting with [0x01, 0xFF]
+    ///         // Including [0x01, 0xFF, 0xFF, 0x00] and beyond
+    ///     }
+    /// } catch SubspaceError.cannotIncrementKey(let message) {
+    ///     print("Cannot create range: \(message)")
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso: `range()` for tuple-encoded data ranges
+    /// - SeeAlso: `FDB.strinc()` for the underlying algorithm
+    public func prefixRange() throws -> (begin: FDB.Bytes, end: FDB.Bytes) {
+        return (prefix, try FDB.strinc(prefix))
+    }
+}

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -73,28 +73,53 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
     case uuid(UUID)
     case versionstamp(Versionstamp)
 
-    func encode() -> FDB.Bytes {
+    var encodedCount: Int {
         switch self {
         case .null:
-            return [TupleTypeCode.null.rawValue]
+            return 1
         case let .bytes(b):
-            return b.encodeTuple()
+            return b.encodedTupleCount
         case let .string(s):
-            return s.encodeTuple()
+            return s.encodedTupleCount
         case let .nested(t):
-            return t.encodeTuple()
+            return t.encodedTupleCount
         case let .int(i):
-            return i.encodeTuple()
+            return i.encodedTupleCount
         case let .float(f):
-            return f.encodeTuple()
+            return f.encodedTupleCount
         case let .double(d):
-            return d.encodeTuple()
+            return d.encodedTupleCount
         case let .bool(b):
-            return b.encodeTuple()
+            return b.encodedTupleCount
         case let .uuid(u):
-            return u.encodeTuple()
+            return u.encodedTupleCount
         case let .versionstamp(v):
-            return v.encodeTuple()
+            return v.encodedTupleCount
+        }
+    }
+
+    func encode(into encoded: inout FDB.Bytes) {
+        switch self {
+        case .null:
+            encoded.append(TupleTypeCode.null.rawValue)
+        case let .bytes(b):
+            b.encodeTuple(into: &encoded)
+        case let .string(s):
+            s.encodeTuple(into: &encoded)
+        case let .nested(t):
+            t.encodeTuple(into: &encoded)
+        case let .int(i):
+            i.encodeTuple(into: &encoded)
+        case let .float(f):
+            f.encodeTuple(into: &encoded)
+        case let .double(d):
+            d.encodeTuple(into: &encoded)
+        case let .bool(b):
+            b.encodeTuple(into: &encoded)
+        case let .uuid(u):
+            u.encodeTuple(into: &encoded)
+        case let .versionstamp(v):
+            v.encodeTuple(into: &encoded)
         }
     }
 
@@ -174,7 +199,11 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
     }
 
     public static func < (lhs: TupleElement, rhs: TupleElement) -> Bool {
-        lhs.encode().lexicographicallyPrecedes(rhs.encode())
+        var le = FDB.Bytes()
+        lhs.encode(into: &le)
+        var re = FDB.Bytes()
+        rhs.encode(into: &re)
+        return le.lexicographicallyPrecedes(re)
     }
 }
 
@@ -198,8 +227,9 @@ extension TupleElement: TupleElementConvertible {
 
 /// internal protocol for converting between Tuple elements and byte strings.
 protocol TupleCodable {
-    func encodeTuple() -> FDB.Bytes
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Self
+    var encodedTupleCount: Int { get }
+    func encodeTuple(into: inout FDB.Bytes)
+    static func decodeTuple(from: FDB.Bytes, at: inout Int) throws -> Self
 }
 
 /// A tuple represents an ordered collection of elements that can be encoded to and decoded from bytes.
@@ -230,21 +260,43 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
         return elements[index]
     }
 
-    public func encode() -> FDB.Bytes {
-        var result = FDB.Bytes()
+    public var encodedCount: Int {
+        var result = 0
         for element in elements {
-            result.append(contentsOf: element.encode())
+            result += element.encodedCount
         }
         return result
     }
 
-    public static func decode(from bytes: FDB.Bytes) throws -> Self {
-        var elements: [TupleElement] = []
+    public func encode() -> FDB.Bytes {
+        let count = encodedCount
+        var encoded = FDB.Bytes()
+        encoded.reserveCapacity(count)
+        for element in elements {
+            element.encode(into: &encoded)
+        }
+        return encoded
+    }
+
+    public static func decode(from: FDB.Bytes) throws -> Self {
         var offset = 0
+        return try decode(from: from, at: &offset, nested: false)
+    }
+
+    static func decode(from bytes: FDB.Bytes, at offset: inout Int, nested: Bool) throws -> Self {
+        var elements: [TupleElement] = []
 
         while offset < bytes.count {
             let typeCode = bytes[offset]
             offset += 1
+
+            if nested && typeCode == 0 {
+                if offset < bytes.count && bytes[offset] == 0xFF {
+                    offset += 1
+                } else {
+                    break
+                }
+            }
 
             switch typeCode {
             case TupleTypeCode.null.rawValue:
@@ -337,8 +389,12 @@ extension String: TupleElementConvertible {
 }
 
 extension String: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        var encoded = [TupleTypeCode.string.rawValue]
+    var encodedTupleCount: Int {
+        utf8.count + utf8.count { $0 == 0 } + 2
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.string.rawValue)
         let utf8Bytes = Array(utf8)
 
         for byte in utf8Bytes {
@@ -349,7 +405,6 @@ extension String: TupleCodable {
             }
         }
         encoded.append(0x00)
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> String {
@@ -391,8 +446,12 @@ extension FDB.Bytes: TupleElementConvertible {
 }
 
 extension FDB.Bytes: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        var encoded = [TupleTypeCode.bytes.rawValue]
+    var encodedTupleCount: Int {
+        self.count + self.count { $0 == 0 } + 2
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.bytes.rawValue)
         for byte in self {
             if byte == 0x00 {
                 encoded.append(contentsOf: [0x00, 0xFF])
@@ -401,7 +460,6 @@ extension FDB.Bytes: TupleCodable {
             }
         }
         encoded.append(0x00)
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> FDB.Bytes {
@@ -443,8 +501,12 @@ extension Bool: TupleElementConvertible {
 }
 
 extension Bool: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        return self ? [TupleTypeCode.boolTrue.rawValue] : [TupleTypeCode.boolFalse.rawValue]
+    var encodedTupleCount: Int {
+        2
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(self ? TupleTypeCode.boolTrue.rawValue : TupleTypeCode.boolFalse.rawValue)
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Bool {
@@ -480,12 +542,15 @@ extension Float: TupleElementConvertible {
 }
 
 extension Float: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        var encoded = [TupleTypeCode.float.rawValue]
+    var encodedTupleCount: Int {
+        5
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.float.rawValue)
         let bitPattern = self.bitPattern
         let bytes = withUnsafeBytes(of: bitPattern.bigEndian) { Array($0) }
         encoded.append(contentsOf: bytes)
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Float {
@@ -520,12 +585,15 @@ extension Double: TupleElementConvertible {
 }
 
 extension Double: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        var encoded = [TupleTypeCode.double.rawValue]
+    var encodedTupleCount: Int {
+        9
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.double.rawValue)
         let bitPattern = self.bitPattern
         let bytes = withUnsafeBytes(of: bitPattern.bigEndian) { Array($0) }
         encoded.append(contentsOf: bytes)
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Double {
@@ -560,13 +628,16 @@ extension UUID: TupleElementConvertible {
 }
 
 extension UUID: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        var encoded = [TupleTypeCode.uuid.rawValue]
+    var encodedTupleCount: Int {
+        17
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.uuid.rawValue)
         let (u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15, u16) = uuid
         encoded.append(contentsOf: [
             u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15, u16,
         ])
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> UUID {
@@ -604,10 +675,13 @@ extension Versionstamp: TupleElementConvertible {
 }
 
 extension Versionstamp: TupleCodable {
-    public func encodeTuple() -> FDB.Bytes {
-        var bytes: FDB.Bytes = [TupleTypeCode.versionstamp.rawValue]
-        bytes.append(contentsOf: toBytes())
-        return bytes
+    var  encodedTupleCount: Int {
+        Versionstamp.totalSize
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.versionstamp.rawValue)
+        encoded.append(contentsOf: toBytes())
     }
 
     public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Versionstamp {
@@ -658,41 +732,40 @@ extension Int64: TupleElementConvertible {
 }
 
 extension Int64: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        encodeInt(self)
+    var encodedTupleCount: Int {
+        if self == 0 {
+            return 2
+        } else {
+            return bisectLeft(UInt64((self < 0) ? -self : self)) + 1
+        }
     }
 
-    private func encodeInt(_ value: Int64) -> FDB.Bytes {
-        if value == 0 {
-            return [TupleTypeCode.intZero.rawValue]
-        }
-
-        var encoded = FDB.Bytes()
-        if value > 0 {
-            let n = bisectLeft(UInt64(value))
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        if self == 0 {
+            encoded.append(TupleTypeCode.intZero.rawValue)
+        } else if self > 0 {
+            let n = bisectLeft(UInt64(self))
             encoded.append(TupleTypeCode.intZero.rawValue + UInt8(n))
-            let bigEndianValue = UInt64(bitPattern: value).bigEndian
+            let bigEndianValue = UInt64(bitPattern: self).bigEndian
             let bytes = withUnsafeBytes(of: bigEndianValue) { Array($0) }
             encoded.append(contentsOf: bytes.suffix(n))
         } else {
-            let n = bisectLeft(UInt64(-value))
+            let n = bisectLeft(UInt64(-self))
             encoded.append(TupleTypeCode.intZero.rawValue - UInt8(n))
 
             if n < 8 {
-                let offset = UInt64(sizeLimits[n]) &+ UInt64(bitPattern: value)
+                let offset = UInt64(sizeLimits[n]) &+ UInt64(bitPattern: self)
                 let bigEndianValue = offset.bigEndian
                 let bytes = withUnsafeBytes(of: bigEndianValue) { Array($0) }
                 encoded.append(contentsOf: bytes.suffix(n))
             } else {
                 // n == 8 case
-                let offset = UInt64(bitPattern: value)
+                let offset = UInt64(bitPattern: self)
                 let bigEndianValue = offset.bigEndian
                 let bytes = withUnsafeBytes(of: bigEndianValue) { Array($0) }
                 encoded.append(contentsOf: bytes)
             }
         }
-
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Int64 {
@@ -753,42 +826,34 @@ extension Tuple: TupleElementConvertible {
 }
 
 extension Tuple: TupleCodable {
-    func encodeTuple() -> FDB.Bytes {
-        var encoded = [TupleTypeCode.nested.rawValue]
+    var encodedTupleCount: Int {
+        var result = 2
         for element in elements {
-            let elementBytes = element.encode()
-            for byte in elementBytes {
-                if byte == 0x00 {
-                    encoded.append(contentsOf: [0x00, 0xFF])
-                } else {
-                    encoded.append(byte)
-                }
+            switch element {
+            case .null:
+                result += 2
+            default:
+                result += element.encodedCount
+            }
+        }
+        return result
+    }
+
+    func encodeTuple(into encoded: inout FDB.Bytes) {
+        encoded.append(TupleTypeCode.nested.rawValue)
+        for element in elements {
+            switch element {
+            case .null:
+                encoded.append(contentsOf: [0x00, 0xFF])
+            default:
+                element.encode(into: &encoded)
             }
         }
         encoded.append(0x00)
-        return encoded
     }
 
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Tuple {
-        var nestedBytes = FDB.Bytes()
-
-        while offset < bytes.count {
-            let byte = bytes[offset]
-            offset += 1
-
-            if byte == 0x00 {
-                if offset < bytes.count && bytes[offset] == 0xFF {
-                    offset += 1
-                    nestedBytes.append(0x00)
-                } else {
-                    break
-                }
-            } else {
-                nestedBytes.append(byte)
-            }
-        }
-
-        return try Tuple.decode(from: nestedBytes)
+        return try decode(from: bytes, at: &offset, nested: true)
     }
 }
 
@@ -856,7 +921,10 @@ extension Tuple {
     /// )
     /// ```
     public func encodeWithVersionstamp(prefix: FDB.Bytes = []) throws -> FDB.Bytes {
-        var packed = prefix
+        var encoded = FDB.Bytes()
+        encoded.reserveCapacity(prefix.count + encodedCount + 4)
+        encoded.append(contentsOf: prefix)
+
         var versionstampPosition: Int? = nil
         var incompleteCount = 0
 
@@ -869,13 +937,13 @@ extension Tuple {
                     if versionstampPosition == nil {
                         // Position points to start of 10-byte transaction version
                         // (after type code byte and before the 10-byte placeholder)
-                        versionstampPosition = packed.count + 1  // +1 for type code (0x33)
+                        versionstampPosition = encoded.count + 1  // +1 for type code (0x33)
                     }
                 }
             default:
                 break
             }
-            packed.append(contentsOf: element.encode())
+            element.encode(into: &encoded)
         }
 
         // Validate exactly one incomplete versionstamp
@@ -893,9 +961,9 @@ extension Tuple {
         }
 
         let offset = UInt32(position)
-        withUnsafeBytes(of: offset.littleEndian) { packed.append(contentsOf: $0) }
+        withUnsafeBytes(of: offset.littleEndian) { encoded.append(contentsOf: $0) }
 
-        return packed
+        return encoded
     }
 
     /// Check if tuple contains an incomplete versionstamp

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -213,7 +213,7 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
         self.elements = elements
     }
 
-    public init(_ elements: [TupleElementConvertible]) {
+    public init(_ elements: any Sequence<TupleElementConvertible>) {
         self.init(elements.map { $0.tupleElement() })
     }
 

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -191,7 +191,6 @@ protocol TupleCodable {
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Self
 }
 
-// TODO: Make a TypedTuple so that we don't have to typecast manually.
 /// A tuple represents an ordered collection of elements that can be encoded to and decoded from bytes.
 ///
 /// Tuples can be used as keys in FoundationDB, and their encoding preserves lexicographic ordering.
@@ -763,4 +762,21 @@ extension Int32: TupleElementConvertible {
             return nil
         }
     }
+}
+
+// TODO: Make a TypedTuple so that we don't have to typecast manually.
+
+public func decodeTuple<each T: TupleElementConvertible>(from bytes: FDB.Bytes) throws -> (repeat each T) {
+    let t = try Tuple.decode(from: bytes)
+    var i = 0
+    func _next() -> TupleElement? {
+        let e = t[i]
+        i += 1
+        return e
+    }
+    let st = (repeat (each T).fromTuple(element: _next())!)
+    if i != t.count {
+        throw TupleError.invalidDecoding("Left over tuple elements")
+    }
+    return st
 }

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -27,6 +27,8 @@ public enum TupleError: Error, Sendable {
     case unsupportedType
 }
 
+// MARK: Elements
+
 enum TupleTypeCode: UInt8, CaseIterable {
     case null = 0x00
     case bytes = 0x01
@@ -232,6 +234,8 @@ protocol TupleCodable {
     static func decodeTuple(from: FDB.Bytes, at: inout Int) throws -> Self
 }
 
+// MARK: Tuple object
+
 /// A tuple represents an ordered collection of elements that can be encoded to and decoded from bytes.
 ///
 /// Tuples can be used as keys in FoundationDB, and their encoding preserves lexicographic ordering.
@@ -372,6 +376,8 @@ extension Tuple {
         return elements[index].convert(type)
     }
 }
+
+// MARK: Specific element types
 
 extension String: TupleElementConvertible {
     public func tupleElement() -> TupleElement {
@@ -887,6 +893,8 @@ extension Int32: TupleElementConvertible {
     }
 }
 
+// MARK: Versionstamp support
+
 extension Tuple {
 
     /// Pack tuple with an incomplete versionstamp and append offset
@@ -1003,7 +1011,7 @@ extension Tuple {
     }
 }
 
-// TODO: Make a TypedTuple so that we don't have to typecast manually.
+// MARK: Type-safe tuples
 
 extension Tuple {
     init<each T: TupleElementConvertible>(_ elements: (repeat each T)) {

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -182,6 +182,7 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
 public protocol TupleElementConvertible {
     func tupleElement() -> TupleElement
 
+    // TODO: This could instead be init?, I think. Is that better?
     static func fromTuple(element: TupleElement?) -> Self?
 }
 
@@ -307,6 +308,20 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
 
     public var description: String {
         elements.description
+    }
+}
+
+extension TupleElement {
+    public func convert<T: TupleElementConvertible>(_: T.Type) -> T? {
+        T.fromTuple(element: self)
+    }
+}
+
+extension Tuple {
+    // TODO: Is this worth having?
+    public subscript<T: TupleElementConvertible>(index: Int, as type: T.Type) -> T? {
+        guard index >= 0, index < elements.count else { return nil }
+        return elements[index].convert(type)
     }
 }
 
@@ -926,17 +941,37 @@ extension Tuple {
 
 // TODO: Make a TypedTuple so that we don't have to typecast manually.
 
-public func decodeTuple<each T: TupleElementConvertible>(from bytes: FDB.Bytes) throws -> (repeat each T) {
-    let t = try Tuple.decode(from: bytes)
-    var i = 0
-    func _next() -> TupleElement? {
-        let e = t[i]
-        i += 1
-        return e
+extension Tuple {
+    init<each T: TupleElementConvertible>(_ elements: (repeat each T)) {
+        var tupleElements: [TupleElement] = []
+        for e in repeat each elements {
+            tupleElements.append(e.tupleElement())
+        }
+        self.init(tupleElements)
     }
-    let st = (repeat (each T).fromTuple(element: _next())!)
-    if i != t.count {
-        throw TupleError.invalidDecoding("Left over tuple elements")
+
+    public static func encode<each T: TupleElementConvertible>(_ elements: (repeat each T)) -> FDB.Bytes {
+        // TODO: The DRY version of this that uses the above crashes the compiler.
+        var tupleElements: [TupleElement] = []
+        for e in repeat each elements {
+            tupleElements.append(e.tupleElement())
+        }
+        return Tuple(tupleElements).encode()
     }
-    return st
+
+    public func convert<each T: TupleElementConvertible>(_ type:(repeat each T).Type) -> (repeat each T) {
+        var i = 0
+        func _next() -> TupleElement? {
+            let e = self[i]
+            i += 1
+            return e
+        }
+        let st = (repeat (each T).fromTuple(element: _next())!)
+        return st
+    }
+
+    public static func decode<each T: TupleElementConvertible>(from bytes: FDB.Bytes, as type:(repeat each T).Type = (repeat each T).self) throws -> (repeat each T) {
+        let t = try Tuple.decode(from: bytes)
+        return t.convert(type)
+    }
 }

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -43,16 +43,6 @@ enum TupleTypeCode: UInt8, CaseIterable {
     case versionstamp = 0x33
 }
 
-public protocol TupleElement: Sendable, Hashable, Equatable {
-    func encodeTuple() -> FDB.Bytes
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Self
-}
-
-// TODO: Make it a TypedTuple so that we don't have to typecast manually.
-/// A tuple represents an ordered collection of elements that can be encoded to and decoded from bytes.
-///
-/// Tuples can be used as keys in FoundationDB, and their encoding preserves lexicographic ordering.
-///
 /// ## Equality and Hashing
 ///
 /// Tuple equality is based on the encoded byte representation of each element, which matches
@@ -69,36 +59,181 @@ public protocol TupleElement: Sendable, Hashable, Equatable {
 ///
 /// These semantic differences ensure consistency with FoundationDB's tuple ordering and are
 /// important when using tuples as dictionary keys or in sets.
-public struct Tuple: Sendable, Hashable, Equatable {
-    private let elements: [any TupleElement]
 
-    public init(_ elements: any TupleElement...) {
+@nonexhaustive
+public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
+    case null
+    case bytes(FDB.Bytes)
+    case string(String)
+    case nested(Tuple)
+    case int(Int64)
+    case float(Float)
+    case double(Double)
+    case bool(Bool)
+    case uuid(UUID)
+
+    func encode() -> FDB.Bytes {
+        switch self {
+        case .null:
+            return [TupleTypeCode.null.rawValue]
+        case let .bytes(b):
+            return b.encodeTuple()
+        case let .string(s):
+            return s.encodeTuple()
+        case let .nested(t):
+            return t.encodeTuple()
+        case let .int(i):
+            return i.encodeTuple()
+        case let .float(f):
+            return f.encodeTuple()
+        case let .double(d):
+            return d.encodeTuple()
+        case let .bool(b):
+            return b.encodeTuple()
+        case let .uuid(u):
+            return u.encodeTuple()
+        }
+    }
+
+    public static func == (lhs: TupleElement, rhs: TupleElement) -> Bool {
+        switch lhs {
+        case .null:
+            switch rhs {
+            case .null:
+                return true
+            default:
+                return false
+            }
+        case let .bytes(bl):
+            switch rhs {
+            case let .bytes(br):
+                return bl == br
+            default:
+                return false
+            }
+        case let .string(sl):
+            switch rhs {
+            case let .string(sr):
+                return sl == sr
+            default:
+                return false
+            }
+        case let .nested(tl):
+            switch rhs {
+            case let .nested(tr):
+                return tl == tr
+            default:
+                return false
+            }
+        case let .int(il):
+            switch rhs {
+            case let .int(ir):
+                return il == ir
+            default:
+                return false
+            }
+        case let .float(fl):
+            switch rhs {
+            case let .float(fr):
+                return fl.bitPattern == fr.bitPattern
+            default:
+                return false
+            }
+        case let .double(dl):
+            switch rhs {
+            case let .double(dr):
+                return dl.bitPattern == dr.bitPattern
+            default:
+                return false
+            }
+        case let .bool(bl):
+            switch rhs {
+            case let .bool(br):
+                return bl == br
+            default:
+                return false
+            }
+        case let .uuid(ul):
+            switch rhs {
+            case let .uuid(ur):
+                return ul == ur
+            default:
+                return false
+            }
+        }
+    }
+
+    public static func < (lhs: TupleElement, rhs: TupleElement) -> Bool {
+        lhs.encode().lexicographicallyPrecedes(rhs.encode())
+    }
+}
+
+// public protocol for converting between Swift native types and Tuple element types.
+public protocol TupleElementConvertible {
+    func tupleElement() -> TupleElement
+
+    static func fromTuple(element: TupleElement?) -> Self?
+}
+
+extension TupleElement: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        self
+    }
+
+    public static func fromTuple(element: TupleElement?) -> TupleElement? {
+        element
+    }
+}
+
+// internal protocol for converting between Tuple elements and byte strings.
+protocol TupleCodable {
+    func encodeTuple() -> FDB.Bytes
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Self
+}
+
+// TODO: Make a TypedTuple so that we don't have to typecast manually.
+/// A tuple represents an ordered collection of elements that can be encoded to and decoded from bytes.
+///
+/// Tuples can be used as keys in FoundationDB, and their encoding preserves lexicographic ordering.
+///
+public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConvertible {
+    // TODO: Any issues with making this public?
+    public let elements: [TupleElement]
+
+    public init(_ elements: [TupleElement]) {
         self.elements = elements
     }
 
-    public init(_ elements: [any TupleElement]) {
-        self.elements = elements
+    public init(_ elements: [TupleElementConvertible]) {
+        self.init(elements.map { $0.tupleElement() })
     }
 
-    public subscript(index: Int) -> (any TupleElement)? {
+    public init(_ elements: TupleElementConvertible...) {
+        self.init(elements)
+    }
+
+    // TODO: Result is optional, like a Dictionary and not like a Collection. Is that right?
+    //  Should this implement more of [RandomAccess]Collection or is using elements array sufficient?
+
+    public subscript(index: Int) -> TupleElement? {
         guard index >= 0, index < elements.count else { return nil }
         return elements[index]
     }
 
     public var count: Int {
-        return elements.count
+        elements.count
     }
 
     public func encode() -> FDB.Bytes {
         var result = FDB.Bytes()
         for element in elements {
-            result.append(contentsOf: element.encodeTuple())
+            result.append(contentsOf: element.encode())
         }
         return result
     }
 
-    public static func decode(from bytes: FDB.Bytes) throws -> [any TupleElement] {
-        var elements: [any TupleElement] = []
+    public static func decode(from bytes: FDB.Bytes) throws -> Self {
+        var elements: [TupleElement] = []
         var offset = 0
 
         while offset < bytes.count {
@@ -107,93 +242,79 @@ public struct Tuple: Sendable, Hashable, Equatable {
 
             switch typeCode {
             case TupleTypeCode.null.rawValue:
-                elements.append(TupleNil())
+                elements.append(TupleElement.null)
             case TupleTypeCode.bytes.rawValue:
                 let element = try FDB.Bytes.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.string.rawValue:
                 let element = try String.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.boolFalse.rawValue, TupleTypeCode.boolTrue.rawValue:
                 let element = try Bool.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.float.rawValue:
                 let element = try Float.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.double.rawValue:
                 let element = try Double.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.uuid.rawValue:
                 let element = try UUID.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.intZero.rawValue:
-                elements.append(0)
+                elements.append(TupleElement.int(0))
             case TupleTypeCode.negativeIntStart.rawValue ... TupleTypeCode.positiveIntEnd.rawValue:
                 let element = try Int64.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             case TupleTypeCode.nested.rawValue:
                 let element = try Tuple.decodeTuple(from: bytes, at: &offset)
-                elements.append(element)
+                elements.append(element.tupleElement())
             default:
                 throw TupleError.invalidDecoding("Unknown type code: \(typeCode)")
             }
         }
 
-        return elements
+        return Self(elements)
     }
 
-    public static func == (lhs: Tuple, rhs: Tuple) -> Bool {
-        guard lhs.count == rhs.count else { return false }
-
-        for i in 0..<lhs.count {
-            // Swift's type system doesn't allow comparing `any Protocol` existentials directly,
-            // even though TupleElement requires Equatable conformance. We compare encoded bytes
-            // instead, which is semantically correct since tuple encoding is canonical:
-            // equal values always produce equal encodings.
-            //
-            // Note: This means Float/Double comparison follows bit-pattern equality rather than
-            // IEEE 754 equality (e.g., +0.0 and -0.0 are unequal, NaN values with the same bit
-            // pattern are equal). See the Tuple documentation for details.
-            if lhs.elements[i].encodeTuple() != rhs.elements[i].encodeTuple() {
+    public static func < (lhs: Tuple, rhs: Tuple) -> Bool {
+        let lc = lhs.count
+        let rc = rhs.count
+        for i in 0..<min(lc, rc) {
+            let le = lhs.elements[i]
+            let re = rhs.elements[i]
+            if le < re {
+                return true
+            }
+            if le > re {
                 return false
             }
         }
-        return true
+        return lc < rc
     }
 
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(elements.count)
-        for element in elements {
-            // Swift's type system doesn't allow hashing `any Protocol` existentials directly,
-            // even though TupleElement requires Hashable conformance. We hash encoded bytes
-            // instead, which ensures consistency with the equality implementation above.
-            hasher.combine(element.encodeTuple())
+    public var description: String {
+        elements.description
+    }
+}
+
+extension String: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .string(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> String? {
+        switch element {
+        case let .string(s):
+            return s
+        default:
+            return nil
         }
     }
 }
 
-struct TupleNil: TupleElement {
+extension String: TupleCodable {
     func encodeTuple() -> FDB.Bytes {
-        return [TupleTypeCode.null.rawValue]
-    }
-
-    static func decodeTuple(from _: FDB.Bytes, at _: inout Int) throws -> TupleNil {
-        return TupleNil()
-    }
-
-    static func == (lhs: TupleNil, rhs: TupleNil) -> Bool {
-        // All TupleNil instances are equal (representing null/nil)
-        return true
-    }
-
-    func hash(into hasher: inout Hasher) {
-        // Use a constant value for consistency with the null type code
-        hasher.combine(TupleTypeCode.null.rawValue)
-    }
-}
-
-extension String: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
         var encoded = [TupleTypeCode.string.rawValue]
         let utf8Bytes = Array(utf8)
 
@@ -208,7 +329,7 @@ extension String: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> String {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> String {
         var decoded = FDB.Bytes()
 
         while offset < bytes.count {
@@ -231,8 +352,23 @@ extension String: TupleElement {
     }
 }
 
-extension FDB.Bytes: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
+extension FDB.Bytes: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .bytes(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> FDB.Bytes? {
+        switch element {
+        case let .bytes(b):
+            return b
+        default:
+            return nil
+        }
+    }
+}
+
+extension FDB.Bytes: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
         var encoded = [TupleTypeCode.bytes.rawValue]
         for byte in self {
             if byte == 0x00 {
@@ -245,7 +381,7 @@ extension FDB.Bytes: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> FDB.Bytes {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> FDB.Bytes {
         var decoded = FDB.Bytes()
 
         while offset < bytes.count {
@@ -268,12 +404,27 @@ extension FDB.Bytes: TupleElement {
     }
 }
 
-extension Bool: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
+extension Bool: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .bool(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> Bool? {
+        switch element {
+        case let .bool(b):
+            return b
+        default:
+            return nil
+        }
+    }
+}
+
+extension Bool: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
         return self ? [TupleTypeCode.boolTrue.rawValue] : [TupleTypeCode.boolFalse.rawValue]
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Bool {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Bool {
         guard offset > 0 else {
             throw TupleError.invalidDecoding("Bool decoding requires type code")
         }
@@ -290,8 +441,23 @@ extension Bool: TupleElement {
     }
 }
 
-extension Float: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
+extension Float: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .float(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> Float? {
+        switch element {
+        case let .float(f):
+            return f
+        default:
+            return nil
+        }
+    }
+}
+
+extension Float: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
         var encoded = [TupleTypeCode.float.rawValue]
         let bitPattern = self.bitPattern
         let bytes = withUnsafeBytes(of: bitPattern.bigEndian) { Array($0) }
@@ -299,7 +465,7 @@ extension Float: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Float {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Float {
         guard offset + 4 <= bytes.count else {
             throw TupleError.invalidDecoding("Not enough bytes for Float")
         }
@@ -315,8 +481,23 @@ extension Float: TupleElement {
     }
 }
 
-extension Double: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
+extension Double: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .double(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> Double? {
+        switch element {
+        case let .double(d):
+            return d
+        default:
+            return nil
+        }
+    }
+}
+
+extension Double: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
         var encoded = [TupleTypeCode.double.rawValue]
         let bitPattern = self.bitPattern
         let bytes = withUnsafeBytes(of: bitPattern.bigEndian) { Array($0) }
@@ -324,7 +505,7 @@ extension Double: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Double {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Double {
         guard offset + 8 <= bytes.count else {
             throw TupleError.invalidDecoding("Not enough bytes for Double")
         }
@@ -340,8 +521,23 @@ extension Double: TupleElement {
     }
 }
 
-extension UUID: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
+extension UUID: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .uuid(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> UUID? {
+        switch element {
+        case let .uuid(u):
+            return u
+        default:
+            return nil
+        }
+    }
+}
+
+extension UUID: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
         var encoded = [TupleTypeCode.uuid.rawValue]
         let (u1, u2, u3, u4, u5, u6, u7, u8, u9, u10, u11, u12, u13, u14, u15, u16) = uuid
         encoded.append(contentsOf: [
@@ -350,7 +546,7 @@ extension UUID: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> UUID {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> UUID {
         guard offset + 16 <= bytes.count else {
             throw TupleError.invalidDecoding("Not enough bytes for UUID")
         }
@@ -389,9 +585,24 @@ private func bisectLeft(_ value: UInt64) -> Int {
     return n
 }
 
-extension Int64: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
-        return encodeInt(self)
+extension Int64: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .int(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> Int64? {
+        switch element {
+        case let .int(i):
+            return i
+        default:
+            return nil
+        }
+    }
+}
+
+extension Int64: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
+        encodeInt(self)
     }
 
     private func encodeInt(_ value: Int64) -> FDB.Bytes {
@@ -427,7 +638,7 @@ extension Int64: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Int64 {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Int64 {
         guard offset > 0 else {
             throw TupleError.invalidDecoding("Int64 decoding requires type code")
         }
@@ -469,11 +680,26 @@ extension Int64: TupleElement {
     }
 }
 
-extension Tuple: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
+extension Tuple: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .nested(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> Tuple? {
+        switch element {
+        case let .nested(t):
+            return t
+        default:
+            return nil
+        }
+    }
+}
+
+extension Tuple: TupleCodable {
+    func encodeTuple() -> FDB.Bytes {
         var encoded = [TupleTypeCode.nested.rawValue]
         for element in elements {
-            let elementBytes = element.encodeTuple()
+            let elementBytes = element.encode()
             for byte in elementBytes {
                 if byte == 0x00 {
                     encoded.append(contentsOf: [0x00, 0xFF])
@@ -486,7 +712,7 @@ extension Tuple: TupleElement {
         return encoded
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Tuple {
+    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Tuple {
         var nestedBytes = FDB.Bytes()
 
         while offset < bytes.count {
@@ -505,54 +731,36 @@ extension Tuple: TupleElement {
             }
         }
 
-        let nestedElements = try Tuple.decode(from: nestedBytes)
-        return Tuple(nestedElements)
+        return try Tuple.decode(from: nestedBytes)
     }
 }
 
-extension Int: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
-        return Int64(self).encodeTuple()
+extension Int: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .int(Int64(self))
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Int {
-        let value = try Int64.decodeTuple(from: bytes, at: &offset)
-        guard value >= Int.min && value <= Int.max else {
-            throw TupleError.invalidDecoding("Int64 value \(value) out of range for Int")
+    public static func fromTuple(element: TupleElement?) -> Int? {
+        switch element {
+        case let .int(i):
+            return Int(i)
+        default:
+            return nil
         }
-        return Int(value)
     }
 }
 
-extension Int32: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
-        return Int64(self).encodeTuple()
+extension Int32: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .int(Int64(self))
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Int32 {
-        let value = try Int64.decodeTuple(from: bytes, at: &offset)
-        guard value >= Int32.min && value <= Int32.max else {
-            throw TupleError.invalidDecoding("Int64 value \(value) out of range for Int32")
+    public static func fromTuple(element: TupleElement?) -> Int32? {
+        switch element {
+        case let .int(i):
+            return Int32(i)
+        default:
+            return nil
         }
-        return Int32(value)
-    }
-}
-
-extension UInt64: TupleElement {
-    public func encodeTuple() -> FDB.Bytes {
-        if self <= Int64.max {
-            return Int64(self).encodeTuple()
-        } else {
-            return Int64.max.encodeTuple()
-        }
-    }
-
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> UInt64 {
-        let value = try Int64.decodeTuple(from: bytes, at: &offset)
-        guard value >= 0 else {
-            throw TupleError.invalidDecoding(
-                "Negative value \(value) cannot be converted to UInt64")
-        }
-        return UInt64(value)
     }
 }

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -231,7 +231,7 @@ extension TupleElement: TupleElementConvertible {
 protocol TupleCodable {
     var encodedTupleCount: Int { get }
     func encodeTuple(into: inout FDB.Bytes)
-    static func decodeTuple(from: FDB.Bytes, at: inout Int) throws -> Self
+    static func decodeTuple<B: Collection<UInt8>>(from: B, at: inout B.Index, typeCode: UInt8) throws -> Self
 }
 
 // MARK: Tuple object
@@ -282,21 +282,21 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
         return encoded
     }
 
-    public static func decode(from: FDB.Bytes) throws -> Self {
-        var offset = 0
-        return try decode(from: from, at: &offset, nested: false)
+    public static func decode<B: Collection<UInt8>>(from bytes: B) throws -> Self {
+        var offset = bytes.startIndex
+        return try decode(from: bytes, at: &offset, nested: false)
     }
 
-    static func decode(from bytes: FDB.Bytes, at offset: inout Int, nested: Bool) throws -> Self {
+    static func decode<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, nested: Bool) throws -> Self {
         var elements: [TupleElement] = []
 
-        while offset < bytes.count {
+        while offset != bytes.endIndex {
             let typeCode = bytes[offset]
-            offset += 1
+            offset = bytes.index(after: offset)
 
             if nested && typeCode == 0 {
-                if offset < bytes.count && bytes[offset] == 0xFF {
-                    offset += 1
+                if offset != bytes.endIndex && bytes[offset] == 0xFF {
+                    offset = bytes.index(after: offset)
                 } else {
                     break
                 }
@@ -306,33 +306,33 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
             case TupleTypeCode.null.rawValue:
                 elements.append(TupleElement.null)
             case TupleTypeCode.bytes.rawValue:
-                let element = try FDB.Bytes.decodeTuple(from: bytes, at: &offset)
+                let element = try FDB.Bytes.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.string.rawValue:
-                let element = try String.decodeTuple(from: bytes, at: &offset)
+                let element = try String.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.boolFalse.rawValue, TupleTypeCode.boolTrue.rawValue:
-                let element = try Bool.decodeTuple(from: bytes, at: &offset)
+                let element = try Bool.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.float.rawValue:
-                let element = try Float.decodeTuple(from: bytes, at: &offset)
+                let element = try Float.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.double.rawValue:
-                let element = try Double.decodeTuple(from: bytes, at: &offset)
+                let element = try Double.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.uuid.rawValue:
-                let element = try UUID.decodeTuple(from: bytes, at: &offset)
+                let element = try UUID.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.versionstamp.rawValue:
-                let element = try Versionstamp.decodeTuple(from: bytes, at: &offset)
+                let element = try Versionstamp.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.intZero.rawValue:
                 elements.append(TupleElement.int(0))
             case TupleTypeCode.negativeIntStart.rawValue ... TupleTypeCode.positiveIntEnd.rawValue:
-                let element = try Int64.decodeTuple(from: bytes, at: &offset)
+                let element = try Int64.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             case TupleTypeCode.nested.rawValue:
-                let element = try Tuple.decodeTuple(from: bytes, at: &offset)
+                let element = try Tuple.decodeTuple(from: bytes, at: &offset, typeCode: typeCode)
                 elements.append(element.tupleElement())
             default:
                 throw TupleError.invalidDecoding("Unknown type code: \(typeCode)")
@@ -401,7 +401,7 @@ extension String: TupleCodable {
 
     func encodeTuple(into encoded: inout FDB.Bytes) {
         encoded.append(TupleTypeCode.string.rawValue)
-        let utf8Bytes = Array(utf8)
+        let utf8Bytes = utf8
 
         for byte in utf8Bytes {
             if byte == 0x00 {
@@ -413,16 +413,16 @@ extension String: TupleCodable {
         encoded.append(0x00)
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> String {
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> String {
         var decoded = FDB.Bytes()
 
-        while offset < bytes.count {
+        while offset != bytes.endIndex {
             let byte = bytes[offset]
-            offset += 1
+            offset = bytes.index(after: offset)
 
             if byte == 0x00 {
-                if offset < bytes.count && bytes[offset] == 0xFF {
-                    offset += 1
+                if offset != bytes.endIndex && bytes[offset] == 0xFF {
+                    offset = bytes.index(after: offset)
                     decoded.append(0x00)
                 } else {
                     break
@@ -468,16 +468,16 @@ extension FDB.Bytes: TupleCodable {
         encoded.append(0x00)
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> FDB.Bytes {
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> FDB.Bytes {
         var decoded = FDB.Bytes()
 
-        while offset < bytes.count {
+        while offset != bytes.endIndex {
             let byte = bytes[offset]
-            offset += 1
+            offset = bytes.index(after: offset)
 
             if byte == 0x00 {
-                if offset < bytes.count && bytes[offset] == 0xFF {
-                    offset += 1
+                if offset != bytes.endIndex && bytes[offset] == 0xFF {
+                    offset = bytes.index(after: offset)
                     decoded.append(0x00)
                 } else {
                     break
@@ -515,12 +515,7 @@ extension Bool: TupleCodable {
         encoded.append(self ? TupleTypeCode.boolTrue.rawValue : TupleTypeCode.boolFalse.rawValue)
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Bool {
-        guard offset > 0 else {
-            throw TupleError.invalidDecoding("Bool decoding requires type code")
-        }
-        let typeCode = bytes[offset - 1]
-
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Bool {
         switch typeCode {
         case TupleTypeCode.boolTrue.rawValue:
             return true
@@ -559,13 +554,14 @@ extension Float: TupleCodable {
         encoded.append(contentsOf: bytes)
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Float {
-        guard offset + 4 <= bytes.count else {
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Float {
+        var offset4 = offset
+        guard bytes.formIndex(&offset4, offsetBy: 4, limitedBy: bytes.endIndex) else {
             throw TupleError.invalidDecoding("Not enough bytes for Float")
         }
 
-        let floatBytes = Array(bytes[offset ..< offset + 4])
-        offset += 4
+        let floatBytes = Array(bytes[offset ..< offset4])
+        offset = offset4
 
         let bigEndianValue = floatBytes.withUnsafeBytes { bytes in
             bytes.load(as: UInt32.self)
@@ -602,13 +598,14 @@ extension Double: TupleCodable {
         encoded.append(contentsOf: bytes)
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Double {
-        guard offset + 8 <= bytes.count else {
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Double {
+        var offset8 = offset
+        guard bytes.formIndex(&offset8, offsetBy: 8, limitedBy: bytes.endIndex) else {
             throw TupleError.invalidDecoding("Not enough bytes for Double")
         }
 
-        let doubleBytes = Array(bytes[offset ..< offset + 8])
-        offset += 8
+        let doubleBytes = Array(bytes[offset ..< offset8])
+        offset = offset8
 
         let bigEndianValue = doubleBytes.withUnsafeBytes { bytes in
             bytes.load(as: UInt64.self)
@@ -646,13 +643,14 @@ extension UUID: TupleCodable {
         ])
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> UUID {
-        guard offset + 16 <= bytes.count else {
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> UUID {
+        var offset16 = offset
+        guard bytes.formIndex(&offset16, offsetBy: 16, limitedBy: bytes.endIndex) else {
             throw TupleError.invalidDecoding("Not enough bytes for UUID")
         }
 
-        let uuidBytes = Array(bytes[offset ..< offset + 16])
-        offset += 16
+        let uuidBytes = Array(bytes[offset ..< offset16])
+        offset = offset16
 
         let uuidTuple = (
             uuidBytes[0], uuidBytes[1], uuidBytes[2], uuidBytes[3],
@@ -690,13 +688,14 @@ extension Versionstamp: TupleCodable {
         encoded.append(contentsOf: toBytes())
     }
 
-    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Versionstamp {
-        guard offset + Versionstamp.totalSize <= bytes.count else {
-            throw TupleError.invalidEncoding
+    public static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Versionstamp {
+        var offsetV = offset
+        guard bytes.formIndex(&offsetV, offsetBy: Versionstamp.totalSize, limitedBy: bytes.endIndex) else {
+            throw TupleError.invalidDecoding("Not enough bytes for versionstamp")
         }
 
-        let versionstampBytes = Array(bytes[offset..<(offset + Versionstamp.totalSize)])
-        offset += Versionstamp.totalSize
+        let versionstampBytes = Array(bytes[offset..<offsetV])
+        offset = offsetV
 
         return try Versionstamp.fromBytes(versionstampBytes)
     }
@@ -774,12 +773,7 @@ extension Int64: TupleCodable {
         }
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Int64 {
-        guard offset > 0 else {
-            throw TupleError.invalidDecoding("Int64 decoding requires type code")
-        }
-        let typeCode = bytes[offset - 1]
-
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Int64 {
         if typeCode == TupleTypeCode.intZero.rawValue {
             return 0
         }
@@ -791,9 +785,14 @@ extension Int64: TupleCodable {
             neg = true
         }
 
+        var offsetN = offset
+        guard bytes.formIndex(&offsetN, offsetBy: n, limitedBy: bytes.endIndex) else {
+            throw TupleError.invalidDecoding("Not enough bytes for integer")
+        }
+
         var bp = [UInt8](repeating: 0, count: 8)
-        bp.replaceSubrange((8 - n) ..< 8, with: bytes[offset ... (offset + n - 1)])
-        offset += n
+        bp.replaceSubrange((8 - n) ..< 8, with: bytes[offset..<offsetN])
+        offset = offsetN
 
         var ret: Int64 = 0
         for byte in bp {
@@ -858,7 +857,7 @@ extension Tuple: TupleCodable {
         encoded.append(0x00)
     }
 
-    static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Tuple {
+    static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Tuple {
         return try decode(from: bytes, at: &offset, nested: true)
     }
 }

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -213,7 +213,6 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
 public protocol TupleElementConvertible {
     func tupleElement() -> TupleElement
 
-    // TODO: This could instead be init?, I think. Is that better?
     static func fromTuple(element: TupleElement) -> Self?
 }
 
@@ -241,7 +240,6 @@ protocol TupleCodable {
 /// Tuples can be used as keys in FoundationDB, and their encoding preserves lexicographic ordering.
 ///
 public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConvertible {
-    // TODO: Any issues with making this public?
     public let elements: [TupleElement]
 
     public init(_ elements: [TupleElement]) {
@@ -370,7 +368,6 @@ extension TupleElement {
 }
 
 extension Tuple {
-    // TODO: Is this worth having?
     public subscript<T: TupleElementConvertible>(index: Int, as type: T.Type) -> T? {
         guard index >= 0, index < elements.count else { return nil }
         return elements[index].convert(type)
@@ -1027,7 +1024,7 @@ extension Tuple {
     }
 
     public static func encode<each T: TupleElementConvertible>(_ elements: (repeat each T)) -> FDB.Bytes {
-        // TODO: The DRY version of this that uses the above crashes the compiler.
+        // TODO: The DRY version of this that uses the above crashes / hangs the compiler.
         var tupleElements: [TupleElement] = []
         for e in repeat each elements {
             tupleElements.append(e.tupleElement())

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -550,8 +550,9 @@ extension Float: TupleCodable {
     func encodeTuple(into encoded: inout FDB.Bytes) {
         encoded.append(TupleTypeCode.float.rawValue)
         let bitPattern = self.bitPattern
-        let bytes = withUnsafeBytes(of: bitPattern.bigEndian) { Array($0) }
-        encoded.append(contentsOf: bytes)
+        withUnsafeBytes(of: bitPattern.bigEndian) { bytes in
+            encoded.append(contentsOf: bytes)
+        }
     }
 
     static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Float {
@@ -594,8 +595,9 @@ extension Double: TupleCodable {
     func encodeTuple(into encoded: inout FDB.Bytes) {
         encoded.append(TupleTypeCode.double.rawValue)
         let bitPattern = self.bitPattern
-        let bytes = withUnsafeBytes(of: bitPattern.bigEndian) { Array($0) }
-        encoded.append(contentsOf: bytes)
+        withUnsafeBytes(of: bitPattern.bigEndian) { bytes in
+            encoded.append(contentsOf: bytes)
+        }
     }
 
     static func decodeTuple<B: Collection<UInt8>>(from bytes: B, at offset: inout B.Index, typeCode: UInt8) throws -> Double {
@@ -752,8 +754,9 @@ extension Int64: TupleCodable {
             let n = bisectLeft(UInt64(self))
             encoded.append(TupleTypeCode.intZero.rawValue + UInt8(n))
             let bigEndianValue = UInt64(bitPattern: self).bigEndian
-            let bytes = withUnsafeBytes(of: bigEndianValue) { Array($0) }
-            encoded.append(contentsOf: bytes.suffix(n))
+            withUnsafeBytes(of: bigEndianValue) { bytes in
+                encoded.append(contentsOf: bytes.suffix(n))
+            }
         } else {
             let n = bisectLeft(UInt64(-self))
             encoded.append(TupleTypeCode.intZero.rawValue - UInt8(n))
@@ -761,14 +764,16 @@ extension Int64: TupleCodable {
             if n < 8 {
                 let offset = UInt64(sizeLimits[n]) &+ UInt64(bitPattern: self)
                 let bigEndianValue = offset.bigEndian
-                let bytes = withUnsafeBytes(of: bigEndianValue) { Array($0) }
-                encoded.append(contentsOf: bytes.suffix(n))
+                withUnsafeBytes(of: bigEndianValue) { bytes in
+                    encoded.append(contentsOf: bytes.suffix(n))
+                }
             } else {
                 // n == 8 case
                 let offset = UInt64(bitPattern: self)
                 let bigEndianValue = offset.bigEndian
-                let bytes = withUnsafeBytes(of: bigEndianValue) { Array($0) }
-                encoded.append(contentsOf: bytes)
+                withUnsafeBytes(of: bigEndianValue) { bytes in
+                    encoded.append(contentsOf: bytes)
+                }
             }
         }
     }

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -183,7 +183,7 @@ public protocol TupleElementConvertible {
     func tupleElement() -> TupleElement
 
     // TODO: This could instead be init?, I think. Is that better?
-    static func fromTuple(element: TupleElement?) -> Self?
+    static func fromTuple(element: TupleElement) -> Self?
 }
 
 extension TupleElement: TupleElementConvertible {
@@ -191,7 +191,7 @@ extension TupleElement: TupleElementConvertible {
         self
     }
 
-    public static func fromTuple(element: TupleElement?) -> TupleElement? {
+    public static func fromTuple(element: TupleElement) -> TupleElement? {
         element
     }
 }
@@ -222,16 +222,12 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
         self.init(elements)
     }
 
-    // TODO: Result is optional, like a Dictionary and not like a Collection. Is that right?
-    //  Should this implement more of [RandomAccess]Collection or is using elements array sufficient?
-
-    public subscript(index: Int) -> TupleElement? {
-        guard index >= 0, index < elements.count else { return nil }
-        return elements[index]
-    }
-
     public var count: Int {
         elements.count
+    }
+
+    public subscript(index: Int) -> TupleElement {
+        return elements[index]
     }
 
     public func encode() -> FDB.Bytes {
@@ -330,7 +326,7 @@ extension String: TupleElementConvertible {
         .string(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> String? {
+    public static func fromTuple(element: TupleElement) -> String? {
         switch element {
         case let .string(s):
             return s
@@ -384,7 +380,7 @@ extension FDB.Bytes: TupleElementConvertible {
         .bytes(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> FDB.Bytes? {
+    public static func fromTuple(element: TupleElement) -> FDB.Bytes? {
         switch element {
         case let .bytes(b):
             return b
@@ -436,7 +432,7 @@ extension Bool: TupleElementConvertible {
         .bool(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> Bool? {
+    public static func fromTuple(element: TupleElement) -> Bool? {
         switch element {
         case let .bool(b):
             return b
@@ -473,7 +469,7 @@ extension Float: TupleElementConvertible {
         .float(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> Float? {
+    public static func fromTuple(element: TupleElement) -> Float? {
         switch element {
         case let .float(f):
             return f
@@ -513,7 +509,7 @@ extension Double: TupleElementConvertible {
         .double(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> Double? {
+    public static func fromTuple(element: TupleElement) -> Double? {
         switch element {
         case let .double(d):
             return d
@@ -553,7 +549,7 @@ extension UUID: TupleElementConvertible {
         .uuid(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> UUID? {
+    public static func fromTuple(element: TupleElement) -> UUID? {
         switch element {
         case let .uuid(u):
             return u
@@ -597,7 +593,7 @@ extension Versionstamp: TupleElementConvertible {
         .versionstamp(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> Versionstamp? {
+    public static func fromTuple(element: TupleElement) -> Versionstamp? {
         switch element {
         case let .versionstamp(v):
             return v
@@ -651,7 +647,7 @@ extension Int64: TupleElementConvertible {
         .int(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> Int64? {
+    public static func fromTuple(element: TupleElement) -> Int64? {
         switch element {
         case let .int(i):
             return i
@@ -746,7 +742,7 @@ extension Tuple: TupleElementConvertible {
         .nested(self)
     }
 
-    public static func fromTuple(element: TupleElement?) -> Tuple? {
+    public static func fromTuple(element: TupleElement) -> Tuple? {
         switch element {
         case let .nested(t):
             return t
@@ -801,7 +797,7 @@ extension Int: TupleElementConvertible {
         .int(Int64(self))
     }
 
-    public static func fromTuple(element: TupleElement?) -> Int? {
+    public static func fromTuple(element: TupleElement) -> Int? {
         switch element {
         case let .int(i):
             return Int(i)
@@ -816,7 +812,7 @@ extension Int32: TupleElementConvertible {
         .int(Int64(self))
     }
 
-    public static func fromTuple(element: TupleElement?) -> Int32? {
+    public static func fromTuple(element: TupleElement) -> Int32? {
         switch element {
         case let .int(i):
             return Int32(i)
@@ -961,7 +957,7 @@ extension Tuple {
 
     public func convert<each T: TupleElementConvertible>(_ type:(repeat each T).Type) -> (repeat each T) {
         var i = 0
-        func _next() -> TupleElement? {
+        func _next() -> TupleElement {
             let e = self[i]
             i += 1
             return e

--- a/Sources/FoundationDB/Tuple.swift
+++ b/Sources/FoundationDB/Tuple.swift
@@ -71,6 +71,7 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
     case double(Double)
     case bool(Bool)
     case uuid(UUID)
+    case versionstamp(Versionstamp)
 
     func encode() -> FDB.Bytes {
         switch self {
@@ -92,6 +93,8 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
             return b.encodeTuple()
         case let .uuid(u):
             return u.encodeTuple()
+        case let .versionstamp(v):
+            return v.encodeTuple()
         }
     }
 
@@ -160,6 +163,13 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
             default:
                 return false
             }
+        case let .versionstamp(vl):
+            switch rhs {
+            case let .versionstamp(vr):
+                return vl == vr
+            default:
+                return false
+            }
         }
     }
 
@@ -168,7 +178,7 @@ public enum TupleElement: Sendable, Hashable, Equatable, Comparable {
     }
 }
 
-// public protocol for converting between Swift native types and Tuple element types.
+/// public protocol for converting between Swift native types and Tuple element types.
 public protocol TupleElementConvertible {
     func tupleElement() -> TupleElement
 
@@ -185,7 +195,7 @@ extension TupleElement: TupleElementConvertible {
     }
 }
 
-// internal protocol for converting between Tuple elements and byte strings.
+/// internal protocol for converting between Tuple elements and byte strings.
 protocol TupleCodable {
     func encodeTuple() -> FDB.Bytes
     static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Self
@@ -259,6 +269,9 @@ public struct Tuple: Sendable, Hashable, Equatable, Comparable, CustomStringConv
                 elements.append(element.tupleElement())
             case TupleTypeCode.uuid.rawValue:
                 let element = try UUID.decodeTuple(from: bytes, at: &offset)
+                elements.append(element.tupleElement())
+            case TupleTypeCode.versionstamp.rawValue:
+                let element = try Versionstamp.decodeTuple(from: bytes, at: &offset)
                 elements.append(element.tupleElement())
             case TupleTypeCode.intZero.rawValue:
                 elements.append(TupleElement.int(0))
@@ -564,6 +577,40 @@ extension UUID: TupleCodable {
     }
 }
 
+extension Versionstamp: TupleElementConvertible {
+    public func tupleElement() -> TupleElement {
+        .versionstamp(self)
+    }
+
+    public static func fromTuple(element: TupleElement?) -> Versionstamp? {
+        switch element {
+        case let .versionstamp(v):
+            return v
+        default:
+            return nil
+        }
+    }
+}
+
+extension Versionstamp: TupleCodable {
+    public func encodeTuple() -> FDB.Bytes {
+        var bytes: FDB.Bytes = [TupleTypeCode.versionstamp.rawValue]
+        bytes.append(contentsOf: toBytes())
+        return bytes
+    }
+
+    public static func decodeTuple(from bytes: FDB.Bytes, at offset: inout Int) throws -> Versionstamp {
+        guard offset + Versionstamp.totalSize <= bytes.count else {
+            throw TupleError.invalidEncoding
+        }
+
+        let versionstampBytes = Array(bytes[offset..<(offset + Versionstamp.totalSize)])
+        offset += Versionstamp.totalSize
+
+        return try Versionstamp.fromBytes(versionstampBytes)
+    }
+}
+
 private let sizeLimits: [UInt64] = [
     (1 << (0 * 8)) - 1,
     (1 << (1 * 8)) - 1,
@@ -760,6 +807,119 @@ extension Int32: TupleElementConvertible {
             return Int32(i)
         default:
             return nil
+        }
+    }
+}
+
+extension Tuple {
+
+    /// Pack tuple with an incomplete versionstamp and append offset
+    ///
+    /// This method packs a tuple that contains exactly one incomplete versionstamp,
+    /// and appends the byte offset where the versionstamp appears.
+    ///
+    /// The offset is always 4 bytes (uint32, little-endian) as per API version 520+.
+    /// API versions prior to 520 used 2-byte offsets but are no longer supported.
+    ///
+    /// The resulting key can be used with `SET_VERSIONSTAMPED_KEY` atomic operation.
+    /// At commit time, FoundationDB will replace the 10-byte placeholder with the
+    /// actual transaction versionstamp.
+    ///
+    /// - Parameter prefix: Optional prefix bytes to prepend (default: empty)
+    /// - Returns: Packed bytes with offset appended
+    /// - Throws: `TupleError.invalidEncoding` if:
+    ///   - No incomplete versionstamp found
+    ///   - Multiple incomplete versionstamps found
+    ///   - Offset exceeds maximum value (65535 for API < 520, 4294967295 for API >= 520)
+    ///
+    /// Example usage:
+    /// ```swift
+    /// let vs = Versionstamp.incomplete(userVersion: 0)
+    /// let tuple = Tuple("user", 12345, vs)
+    /// let key = try tuple.encodeWithVersionstamp()
+    ///
+    /// transaction.atomicOp(
+    ///     key: key,
+    ///     param: [],
+    ///     mutationType: .setVersionstampedKey
+    /// )
+    /// ```
+    public func encodeWithVersionstamp(prefix: FDB.Bytes = []) throws -> FDB.Bytes {
+        var packed = prefix
+        var versionstampPosition: Int? = nil
+        var incompleteCount = 0
+
+        // Encode each element and track incomplete versionstamp position
+        for element in elements {
+            switch element {
+            case let .versionstamp(vs):
+                if !vs.isComplete {
+                    incompleteCount += 1
+                    if versionstampPosition == nil {
+                        // Position points to start of 10-byte transaction version
+                        // (after type code byte and before the 10-byte placeholder)
+                        versionstampPosition = packed.count + 1  // +1 for type code (0x33)
+                    }
+                }
+            default:
+                break
+            }
+            packed.append(contentsOf: element.encode())
+        }
+
+        // Validate exactly one incomplete versionstamp
+        guard incompleteCount == 1, let position = versionstampPosition else {
+            throw TupleError.invalidEncoding
+        }
+
+        // Append offset based on API version
+        // Currently defaults to API 520+ behavior (4-byte offset)
+        // API < 520 used 2-byte offset, but is no longer supported
+
+        // API >= 520: Use 4-byte offset (uint32, little-endian)
+        guard position <= UInt32.max else {
+            throw TupleError.invalidEncoding
+        }
+
+        let offset = UInt32(position)
+        withUnsafeBytes(of: offset.littleEndian) { packed.append(contentsOf: $0) }
+
+        return packed
+    }
+
+    /// Check if tuple contains an incomplete versionstamp
+    /// - Returns: true if any element is an incomplete versionstamp
+    public func hasIncompleteVersionstamp() -> Bool {
+        return elements.contains { element in
+            switch element {
+            case let .versionstamp(vs):
+                return !vs.isComplete
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Count incomplete versionstamps in tuple
+    /// - Returns: Number of incomplete versionstamps
+    public func countIncompleteVersionstamps() -> Int {
+        return elements.count { element in
+            switch element {
+            case let .versionstamp(vs):
+                return !vs.isComplete
+            default:
+                return false
+            }
+        }
+    }
+
+    /// Validate tuple for use with encodeWithVersionstamp()
+    /// - Throws: `TupleError.invalidEncoding` if validation fails
+    public func validateForVersionstamp() throws {
+        let incompleteCount = countIncompleteVersionstamps()
+
+        if incompleteCount != 1 {
+            throw TupleError.invalidEncoding
         }
     }
 }

--- a/Sources/FoundationDB/Types.swift
+++ b/Sources/FoundationDB/Types.swift
@@ -125,6 +125,57 @@ public enum FDB {
             return KeySelector(key: key, orEqual: false, offset: 0)
         }
     }
+
+    /// String increment for raw binary prefixes
+    ///
+    /// Returns the first key that would sort outside the range prefixed by the given byte array.
+    /// This implements the canonical strinc algorithm used in FoundationDB.
+    ///
+    /// The algorithm:
+    /// 1. Strip all trailing 0xFF bytes
+    /// 2. Increment the last remaining byte
+    /// 3. Return the truncated result
+    ///
+    /// This matches the behavior of:
+    /// - Go: `fdb.Strinc()`
+    /// - Java: `ByteArrayUtil.strinc()`
+    /// - Python: `fdb.strinc()`
+    ///
+    /// - Parameter bytes: The byte array to increment
+    /// - Returns: Incremented byte array
+    /// - Throws: `SubspaceError.cannotIncrementKey` if the byte array is empty
+    ///   or contains only 0xFF bytes
+    ///
+    /// ## Example
+    ///
+    /// ```swift
+    /// try FDB.strinc([0x01, 0x02])              // → [0x01, 0x03]
+    /// try FDB.strinc([0x01, 0xFF])              // → [0x02]
+    /// try FDB.strinc([0x01, 0x02, 0xFF, 0xFF])  // → [0x01, 0x03]
+    /// try FDB.strinc([0xFF, 0xFF])              // throws SubspaceError.cannotIncrementKey
+    /// try FDB.strinc([])                        // throws SubspaceError.cannotIncrementKey
+    /// ```
+    ///
+    /// - SeeAlso: `Subspace.prefixRange()` for usage with Subspace
+    public static func strinc(_ bytes: Bytes) throws -> Bytes {
+        // Strip trailing 0xFF bytes
+        var result = bytes
+        while result.last == 0xFF {
+            result.removeLast()
+        }
+
+        // Check if result is empty (input was empty or all 0xFF)
+        if result.isEmpty {
+            throw SubspaceError.cannotIncrementKey(
+                "Key must contain at least one byte not equal to 0xFF"
+            )
+        }
+
+        // Increment the last byte
+        result[result.count - 1] = result[result.count - 1] &+ 1
+
+        return result
+    }
 }
 
 /// Extension making `FDB.Key` conformant to `Selectable`.

--- a/Sources/FoundationDB/Versionstamp.swift
+++ b/Sources/FoundationDB/Versionstamp.swift
@@ -1,0 +1,165 @@
+/*
+ * Versionstamp.swift
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2016-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Represents a FoundationDB versionstamp (96-bit / 12 bytes)
+///
+/// A versionstamp is a 12-byte value consisting of:
+/// - 10 bytes: Transaction version (assigned by FDB at commit time)
+/// - 2 bytes: User-defined version (for ordering within a transaction)
+///
+/// Versionstamps are used for:
+/// - Optimistic concurrency control
+/// - Creating globally unique, monotonically increasing keys
+/// - Maintaining temporal ordering of records
+///
+/// Example usage:
+/// ```swift
+/// // Create an incomplete versionstamp for writing
+/// let vs = Versionstamp.incomplete(userVersion: 0)
+/// let tuple = Tuple("prefix", vs)
+/// let key = try tuple.encodeWithVersionstamp()
+/// transaction.atomicOp(key: key, param: [], mutationType: .setVersionstampedKey)
+///
+/// // After commit, read the completed versionstamp
+/// let committedVersion = try await transaction.getVersionstamp()
+/// let complete = Versionstamp(transactionVersion: committedVersion!, userVersion: 0)
+/// ```
+
+import Foundation
+
+public struct Versionstamp: Sendable, Hashable, Equatable, Comparable, CustomStringConvertible {
+
+    // MARK: - Constants
+
+    /// Size of transaction version in bytes (10 bytes / 80 bits)
+    public static let transactionVersionSize = 10
+
+    /// Size of user version in bytes (2 bytes / 16 bits)
+    public static let userVersionSize = 2
+
+    /// Total size of versionstamp in bytes (12 bytes / 96 bits)
+    public static let totalSize = transactionVersionSize + userVersionSize
+
+    /// Placeholder for incomplete transaction version (10 bytes of 0xFF)
+    private static let incompletePlaceholder: [UInt8] = [UInt8](repeating: 0xFF, count: transactionVersionSize)
+
+    // MARK: - Properties
+
+    /// Transaction version (10 bytes)
+    /// - nil for incomplete versionstamp (to be filled by FDB at commit time)
+    /// - Non-nil for complete versionstamp (after commit)
+    public let transactionVersion: [UInt8]?
+
+    /// User-defined version (2 bytes, big-endian)
+    /// Used for ordering within a single transaction
+    /// Range: 0-65535
+    public let userVersion: UInt16
+
+    // MARK: - Initialization
+
+    /// Create a versionstamp
+    /// - Parameters:
+    ///   - transactionVersion: 10-byte transaction version from FDB (nil for incomplete)
+    ///   - userVersion: User-defined version (0-65535)
+    public init(transactionVersion: [UInt8]?, userVersion: UInt16 = 0) {
+        if let tv = transactionVersion {
+            precondition(
+                tv.count == Self.transactionVersionSize,
+                "Transaction version must be exactly \(Self.transactionVersionSize) bytes"
+            )
+        }
+        self.transactionVersion = transactionVersion
+        self.userVersion = userVersion
+    }
+
+    /// Create an incomplete versionstamp
+    /// - Parameter userVersion: User-defined version (0-65535)
+    /// - Returns: Versionstamp with placeholder transaction version
+    ///
+    /// Use this when creating keys/values that will be filled by FDB at commit time.
+    public static func incomplete(userVersion: UInt16 = 0) -> Versionstamp {
+        return Versionstamp(transactionVersion: nil, userVersion: userVersion)
+    }
+
+    // MARK: - Properties
+
+    /// Check if versionstamp is complete
+    /// - Returns: true if transaction version has been set, false otherwise
+    public var isComplete: Bool {
+        return transactionVersion != nil
+    }
+
+    /// Convert to 12-byte representation
+    /// - Returns: 12-byte array (10 bytes transaction version + 2 bytes user version, big-endian)
+    public func toBytes() -> FDB.Bytes {
+        var bytes = transactionVersion ?? Self.incompletePlaceholder
+
+        // User version is stored as big-endian
+        withUnsafeBytes(of: userVersion.bigEndian) { bytes.append(contentsOf: $0) }
+
+        return bytes
+    }
+
+    /// Create from 12-byte representation
+    /// - Parameter bytes: 12-byte array
+    /// - Returns: Versionstamp
+    /// - Throws: `TupleError.invalidEncoding` if bytes length is not 12
+    public static func fromBytes(_ bytes: FDB.Bytes) throws -> Versionstamp {
+        guard bytes.count == totalSize else {
+            throw TupleError.invalidEncoding
+        }
+
+        let trVersionBytes = Array(bytes.prefix(transactionVersionSize))
+        let userVersionBytes = bytes.suffix(userVersionSize)
+
+        let userVersion = userVersionBytes.withUnsafeBytes {
+            $0.load(as: UInt16.self).bigEndian
+        }
+
+        // Check if transaction version is incomplete (all 0xFF)
+        let isIncomplete = trVersionBytes == incompletePlaceholder
+
+        return Versionstamp(
+            transactionVersion: isIncomplete ? nil : trVersionBytes,
+            userVersion: userVersion
+        )
+    }
+
+    // MARK: - Hashable & Equatable
+    // Compiler-synthesized implementations
+
+    // MARK: - Comparable
+
+    /// Versionstamps are ordered lexicographically by their byte representation
+    public static func < (lhs: Versionstamp, rhs: Versionstamp) -> Bool {
+        return lhs.toBytes().lexicographicallyPrecedes(rhs.toBytes())
+    }
+
+    // MARK: - CustomStringConvertible
+
+    public var description: String {
+        if let tv = transactionVersion {
+            let tvHex = tv.map { String(format: "%02x", $0) }.joined()
+            return "Versionstamp(tr:\(tvHex), user:\(userVersion))"
+        } else {
+            return "Versionstamp(incomplete, user:\(userVersion))"
+        }
+    }
+}

--- a/Tests/FoundationDBTests/FoundationDBTupleTests.swift
+++ b/Tests/FoundationDBTests/FoundationDBTupleTests.swift
@@ -262,10 +262,10 @@ func tupleWithZero() throws {
     let decoded = try Tuple.decode(from: encoded)
 
     #expect(decoded.count == 3, "Should have 3 elements")
-    let decodedString1 = decoded[0]?.convert(String.self)
+    let decodedString1 = decoded[0].convert(String.self)
     #expect(decodedString1 == "hello")
 
-    let decodedInt = decoded[1]?.convert(Int64.self)
+    let decodedInt = decoded[1].convert(Int64.self)
     #expect(decodedInt == 0)
 
     let decodedString2 = decoded[2, as:String.self]

--- a/Tests/FoundationDBTests/FoundationDBTupleTests.swift
+++ b/Tests/FoundationDBTests/FoundationDBTupleTests.swift
@@ -36,7 +36,8 @@ func testTupleNil() throws {
 @Test("TupleString encoding and decoding")
 func tupleString() throws {
     let testString = "Hello, World!"
-    let encoded = testString.encodeTuple()
+    var encoded = FDB.Bytes()
+    testString.encodeTuple(into: &encoded)
 
     #expect(encoded.first == TupleTypeCode.string.rawValue, "TupleString should start with string type code")
     #expect(encoded.last == 0x00, "TupleString should end with null terminator")
@@ -50,7 +51,8 @@ func tupleString() throws {
 @Test("TupleString with null bytes")
 func tupleStringWithNulls() throws {
     let testString = "Hello\u{0}World"
-    let encoded = testString.encodeTuple()
+    var encoded = FDB.Bytes()
+    testString.encodeTuple(into: &encoded)
 
     #expect(encoded.contains(0x00), "Encoded string should contain null bytes")
     #expect(encoded.contains(0xFF), "Null bytes should be escaped with 0xFF")
@@ -65,8 +67,10 @@ func tupleBool() throws {
     let testTrue = true
     let testFalse = false
 
-    let encodedTrue = testTrue.encodeTuple()
-    let encodedFalse = testFalse.encodeTuple()
+    var encodedTrue = FDB.Bytes()
+    testTrue.encodeTuple(into: &encodedTrue)
+    var encodedFalse = FDB.Bytes()
+    testFalse.encodeTuple(into: &encodedFalse)
 
     #expect(encodedTrue == [TupleTypeCode.boolTrue.rawValue], "true should encode to boolTrue type code")
     #expect(encodedFalse == [TupleTypeCode.boolFalse.rawValue], "false should encode to boolFalse type code")
@@ -84,7 +88,8 @@ func tupleBool() throws {
 @Test("TupleFloat encoding and decoding")
 func tupleFloat() throws {
     let testFloat: Float = 3.14159
-    let encoded = testFloat.encodeTuple()
+    var encoded = FDB.Bytes()
+    testFloat.encodeTuple(into: &encoded)
 
     #expect(encoded.first == TupleTypeCode.float.rawValue, "Float should start with float type code")
     #expect(encoded.count == 5, "Float should be 5 bytes (1 type code + 4 data)")
@@ -98,7 +103,8 @@ func tupleFloat() throws {
 @Test("TupleDouble encoding and decoding")
 func tupleDouble() throws {
     let testDouble = 3.141592653589793
-    let encoded = testDouble.encodeTuple()
+    var encoded = FDB.Bytes()
+    testDouble.encodeTuple(into: &encoded)
 
     #expect(encoded.first == TupleTypeCode.double.rawValue, "Double should start with double type code")
     #expect(encoded.count == 9, "Double should be 9 bytes (1 type code + 8 data)")
@@ -112,7 +118,8 @@ func tupleDouble() throws {
 @Test("TupleUUID encoding and decoding")
 func tupleUUID() throws {
     let testUUID = UUID()
-    let encoded = testUUID.encodeTuple()
+    var encoded = FDB.Bytes()
+    testUUID.encodeTuple(into: &encoded)
 
     #expect(encoded.first == TupleTypeCode.uuid.rawValue, "UUID should start with uuid type code")
     #expect(encoded.count == 17, "UUID should be 17 bytes (1 type code + 16 data)")
@@ -126,7 +133,8 @@ func tupleUUID() throws {
 @Test("TupleInt64 encoding and decoding - Zero")
 func tupleInt64Zero() throws {
     let testInt: Int64 = 0
-    let encoded = testInt.encodeTuple()
+    var encoded = FDB.Bytes()
+    testInt.encodeTuple(into: &encoded)
 
     #expect(encoded == [TupleTypeCode.intZero.rawValue], "Zero should encode to intZero type code")
 
@@ -139,7 +147,8 @@ func tupleInt64Zero() throws {
 @Test("TupleInt64 encoding and decoding - Small positive")
 func tupleInt64SmallPositive() throws {
     let testInt: Int64 = 42
-    let encoded = testInt.encodeTuple()
+    var encoded = FDB.Bytes()
+    testInt.encodeTuple(into: &encoded)
 
     #expect(encoded.first == 0x15, "Small positive should use 0x15 type code (positiveInt1)")
 
@@ -152,7 +161,8 @@ func tupleInt64SmallPositive() throws {
 @Test("TupleInt64 encoding and decoding - Very small negative")
 func tupleInt64VerySmallNegative() throws {
     let testInt: Int64 = -42
-    let encoded = testInt.encodeTuple()
+    var encoded = FDB.Bytes()
+    testInt.encodeTuple(into: &encoded)
 
     #expect(encoded.first == 0x13)
 
@@ -165,7 +175,8 @@ func tupleInt64VerySmallNegative() throws {
 @Test("TupleInt64 encoding and decoding - Large negative")
 func tupleInt64LargeNegative() throws {
     let testInt: Int64 = -89_034_333_444
-    let encoded = testInt.encodeTuple()
+    var encoded = FDB.Bytes()
+    testInt.encodeTuple(into: &encoded)
 
     var offset = 1
     let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
@@ -176,7 +187,8 @@ func tupleInt64LargeNegative() throws {
 @Test("TupleInt64 encoding and decoding - Very Large negative")
 func tupleInt64VeryLargeNegative() throws {
     let testInt: Int64 = -(1 << 55) - 34_897_432
-    let encoded = testInt.encodeTuple()
+    var encoded = FDB.Bytes()
+    testInt.encodeTuple(into: &encoded)
 
     var offset = 1
     let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
@@ -187,7 +199,8 @@ func tupleInt64VeryLargeNegative() throws {
 @Test("TupleInt64 encoding and decoding - VeryVery Large negative")
 func tupleInt64VeryLargeNegative2() throws {
     let testInt: Int64 = -(1 << 60) - 34_897_432
-    let encoded = testInt.encodeTuple()
+    var encoded = FDB.Bytes()
+    testInt.encodeTuple(into: &encoded)
 
     var offset = 1
     let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
@@ -200,8 +213,10 @@ func tupleInt64LargeValues() throws {
     let largePositive = Int64.max
     let largeNegative = Int64.min + 1
 
-    let encodedPos = largePositive.encodeTuple()
-    let encodedNeg = largeNegative.encodeTuple()
+    var encodedPos = FDB.Bytes()
+    largePositive.encodeTuple(into: &encodedPos)
+    var encodedNeg = FDB.Bytes()
+    largeNegative.encodeTuple(into: &encodedNeg)
 
     var offsetPos = 1
     var offsetNeg = 1
@@ -309,7 +324,8 @@ func tupleInt64DistributedIntegers() throws {
     var negative = 0
     for _ in 0 ..< 1_000_000 {
         let testInt = nextRandom()
-        let encoded = testInt.encodeTuple()
+        var encoded = FDB.Bytes()
+        testInt.encodeTuple(into: &encoded)
 
         if testInt > 0 {
             positive += 1

--- a/Tests/FoundationDBTests/FoundationDBTupleTests.swift
+++ b/Tests/FoundationDBTests/FoundationDBTupleTests.swift
@@ -262,13 +262,13 @@ func tupleWithZero() throws {
     let decoded = try Tuple.decode(from: encoded)
 
     #expect(decoded.count == 3, "Should have 3 elements")
-    let decodedString1 = String.fromTuple(element: decoded[0])
+    let decodedString1 = decoded[0]?.convert(String.self)
     #expect(decodedString1 == "hello")
 
-    let decodedInt = Int64.fromTuple(element: decoded[1])
+    let decodedInt = decoded[1]?.convert(Int64.self)
     #expect(decodedInt == 0)
 
-    let decodedString2 = String.fromTuple(element: decoded[2])
+    let decodedString2 = decoded[2, as:String.self]
     #expect(decodedString2 == "foo")
 }
 
@@ -510,11 +510,27 @@ func tupleNilPositions() throws {
 
 @Test("Tuple to Swift Tuple")
 func tupleToTuple() throws {
-    let tuple = Tuple("hello", 2, "foo")
+    typealias TupleType = (String, Int, String)
+
+    let swiftTuple: TupleType = ("hello", 2, "foo")
+    let tuple = Tuple(swiftTuple)
 
     let encoded = tuple.encode()
-    let (decodedString1, decodedInt, decodedString2) = try decodeTuple<String, Int, String>(from: encoded)
-    #expect(decodedString1 == "hello")
-    #expect(decodedInt == 2)
-    #expect(decodedString2 == "foo")
+    let decodedTuple = try Tuple.decode(from: encoded, as: TupleType.self)
+    #expect(decodedTuple == swiftTuple)
+
+    let decodedTuple1a = try Tuple.decode(from: encoded, as: (String, Int, String).self)
+    #expect(decodedTuple == decodedTuple1a)
+
+    let encoded2 = Tuple.encode(swiftTuple)
+    #expect(encoded == encoded2)
+
+    let decodedTuple2: TupleType = try Tuple.decode(from: encoded)
+    #expect(decodedTuple == decodedTuple2)
+
+    let decodedTuple2a: (String, Int, String) = try Tuple.decode(from: encoded)
+    #expect(decodedTuple2 == decodedTuple2a)
+
+    let (s1, i2, s3) = try Tuple.decode<String, Int, String>(from: encoded)
+    #expect(decodedTuple == (s1, i2, s3))
 }

--- a/Tests/FoundationDBTests/FoundationDBTupleTests.swift
+++ b/Tests/FoundationDBTests/FoundationDBTupleTests.swift
@@ -43,7 +43,7 @@ func tupleString() throws {
     #expect(encoded.last == 0x00, "TupleString should end with null terminator")
 
     var offset = 1
-    let decoded = try String.decodeTuple(from: encoded, at: &offset)
+    let decoded = try String.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testString, "Should decode back to original string")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -58,7 +58,7 @@ func tupleStringWithNulls() throws {
     #expect(encoded.contains(0xFF), "Null bytes should be escaped with 0xFF")
 
     var offset = 1
-    let decoded = try String.decodeTuple(from: encoded, at: &offset)
+    let decoded = try String.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testString, "Should decode back to original string with nulls")
 }
 
@@ -78,8 +78,8 @@ func tupleBool() throws {
     var offsetTrue = 1
     var offsetFalse = 1
 
-    let decodedTrue = try Bool.decodeTuple(from: encodedTrue, at: &offsetTrue)
-    let decodedFalse = try Bool.decodeTuple(from: encodedFalse, at: &offsetFalse)
+    let decodedTrue = try Bool.decodeTuple(from: encodedTrue, at: &offsetTrue, typeCode: encodedTrue[0])
+    let decodedFalse = try Bool.decodeTuple(from: encodedFalse, at: &offsetFalse, typeCode: encodedFalse[0])
 
     #expect(decodedTrue == true, "Should decode back to true")
     #expect(decodedFalse == false, "Should decode back to false")
@@ -95,7 +95,7 @@ func tupleFloat() throws {
     #expect(encoded.count == 5, "Float should be 5 bytes (1 type code + 4 data)")
 
     var offset = 1
-    let decoded = try Float.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Float.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testFloat, "Should decode back to original float")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -110,7 +110,7 @@ func tupleDouble() throws {
     #expect(encoded.count == 9, "Double should be 9 bytes (1 type code + 8 data)")
 
     var offset = 1
-    let decoded = try Double.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Double.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testDouble, "Should decode back to original double")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -125,7 +125,7 @@ func tupleUUID() throws {
     #expect(encoded.count == 17, "UUID should be 17 bytes (1 type code + 16 data)")
 
     var offset = 1
-    let decoded = try UUID.decodeTuple(from: encoded, at: &offset)
+    let decoded = try UUID.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testUUID, "Should decode back to original UUID")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -139,7 +139,7 @@ func tupleInt64Zero() throws {
     #expect(encoded == [TupleTypeCode.intZero.rawValue], "Zero should encode to intZero type code")
 
     var offset = 1
-    let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testInt, "Should decode back to original zero")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -153,7 +153,7 @@ func tupleInt64SmallPositive() throws {
     #expect(encoded.first == 0x15, "Small positive should use 0x15 type code (positiveInt1)")
 
     var offset = 1
-    let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testInt, "Should decode back to original positive integer")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -167,7 +167,7 @@ func tupleInt64VerySmallNegative() throws {
     #expect(encoded.first == 0x13)
 
     var offset = 1
-    let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testInt, "Should decode back to original positive integer")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -179,7 +179,7 @@ func tupleInt64LargeNegative() throws {
     testInt.encodeTuple(into: &encoded)
 
     var offset = 1
-    let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testInt, "Should decode back to original negative integer")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -191,7 +191,7 @@ func tupleInt64VeryLargeNegative() throws {
     testInt.encodeTuple(into: &encoded)
 
     var offset = 1
-    let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testInt, "Should decode back to original negative integer")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -203,7 +203,7 @@ func tupleInt64VeryLargeNegative2() throws {
     testInt.encodeTuple(into: &encoded)
 
     var offset = 1
-    let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+    let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
     #expect(decoded == testInt, "Should decode back to original negative integer")
     #expect(offset == encoded.count, "Offset should advance to end of encoded data")
 }
@@ -221,8 +221,8 @@ func tupleInt64LargeValues() throws {
     var offsetPos = 1
     var offsetNeg = 1
 
-    let decodedPos = try Int64.decodeTuple(from: encodedPos, at: &offsetPos)
-    let decodedNeg = try Int64.decodeTuple(from: encodedNeg, at: &offsetNeg)
+    let decodedPos = try Int64.decodeTuple(from: encodedPos, at: &offsetPos, typeCode: encodedPos[0])
+    let decodedNeg = try Int64.decodeTuple(from: encodedNeg, at: &offsetNeg, typeCode: encodedNeg[0])
 
     #expect(decodedPos == largePositive, "Should decode back to Int64.max")
     #expect(decodedNeg == largeNegative, "Should decode back to Int64.min")
@@ -334,7 +334,7 @@ func tupleInt64DistributedIntegers() throws {
         }
 
         var offset = 1
-        let decoded = try Int64.decodeTuple(from: encoded, at: &offset)
+        let decoded = try Int64.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
         #expect(decoded == testInt, "Integer \(testInt) should encode and decode correctly")
         #expect(offset == encoded.count, "Offset should advance to end of encoded data")
     }

--- a/Tests/FoundationDBTests/FoundationDBTupleTests.swift
+++ b/Tests/FoundationDBTests/FoundationDBTupleTests.swift
@@ -25,14 +25,12 @@ import Testing
 
 @Test("TupleNil encoding and decoding")
 func testTupleNil() throws {
-    let tupleNil = TupleNil()
-    let encoded = tupleNil.encodeTuple()
+    let tupleNil = Tuple(TupleElement.null)
+    let encoded = tupleNil.encode()
     #expect(encoded == [TupleTypeCode.null.rawValue], "TupleNil should encode to null type code")
 
-    var offset = 1
-    let decoded = try TupleNil.decodeTuple(from: encoded, at: &offset)
-    #expect(type(of: decoded) == TupleNil.self, "Should decode back to TupleNil")
-    #expect(offset == 1, "Offset should not advance for TupleNil")
+    let decoded = try Tuple.decode(from:encoded)
+    #expect(decoded == tupleNil, "Should decode back to original null tuple")
 }
 
 @Test("TupleString encoding and decoding")
@@ -218,31 +216,21 @@ func tupleInt64LargeValues() throws {
 @Test("TupleInt32 encoding and decoding")
 func tupleInt32() throws {
     let testInt: Int32 = -2_034_333_444
-    let encoded = testInt.encodeTuple()
+    let testTuple = Tuple(testInt)
+    let encoded = testTuple.encode()
 
-    var offset = 1
-    let decoded = try Int32.decodeTuple(from: encoded, at: &offset)
-    #expect(decoded == testInt, "Should decode back to original Int32")
+    let decoded = try Tuple.decode(from: encoded)
+    #expect(decoded == testTuple, "Should decode back to original tuple")
 }
 
 @Test("TupleInt encoding and decoding")
 func tupleInt() throws {
     let testInt = 123_456
-    let encoded = testInt.encodeTuple()
+    let testTuple = Tuple(testInt)
+    let encoded = testTuple.encode()
 
-    var offset = 1
-    let decoded = try Int.decodeTuple(from: encoded, at: &offset)
-    #expect(decoded == testInt, "Should decode back to original Int")
-}
-
-@Test("TupleUInt64 encoding and decoding")
-func tupleUInt64() throws {
-    let testUInt: UInt64 = 999_999
-    let encoded = testUInt.encodeTuple()
-
-    var offset = 1
-    let decoded = try UInt64.decodeTuple(from: encoded, at: &offset)
-    #expect(decoded == testUInt, "Should decode back to original UInt64")
+    let decoded = try Tuple.decode(from: encoded)
+    #expect(decoded == testTuple, "Should decode back to original tuple")
 }
 
 @Test("TupleNested encoding and decoding")
@@ -255,14 +243,14 @@ func tupleNested() throws {
 
     #expect(decoded.count == 3, "Should have 3 elements")
 
-    let decodedString1 = decoded[0] as? String
+    let decodedString1  = String.fromTuple(element: decoded[0])
     #expect(decodedString1 == "outer", "First element should be 'outer'")
 
-    let decodedNested = decoded[1] as? Tuple
+    let decodedNested = Tuple.fromTuple(element: decoded[1])
     #expect(decodedNested != nil, "Second element should be a Tuple")
     #expect(decodedNested?.count == 3, "Nested tuple should have 3 elements")
 
-    let decodedString2 = decoded[2] as? String
+    let decodedString2 = String.fromTuple(element: decoded[2])
     #expect(decodedString2 == "end", "Third element should be 'end'")
 }
 
@@ -274,13 +262,13 @@ func tupleWithZero() throws {
     let decoded = try Tuple.decode(from: encoded)
 
     #expect(decoded.count == 3, "Should have 3 elements")
-    let decodedString1 = decoded[0] as? String
+    let decodedString1 = String.fromTuple(element: decoded[0])
     #expect(decodedString1 == "hello")
 
-    let decodedInt = decoded[1] as? Int
+    let decodedInt = Int64.fromTuple(element: decoded[1])
     #expect(decodedInt == 0)
 
-    let decodedString2 = decoded[2] as? String
+    let decodedString2 = String.fromTuple(element: decoded[2])
     #expect(decodedString2 == "foo")
 }
 
@@ -295,14 +283,14 @@ func tupleNestedDeep() throws {
 
     #expect(decoded.count == 3, "Top level should have 3 elements")
 
-    let topString = decoded[0] as? String
+    let topString = String.fromTuple(element: decoded[0])
     #expect(topString == "top", "First element should be 'top'")
 
-    let middleTuple = decoded[1] as? Tuple
+    let middleTuple = Tuple.fromTuple(element: decoded[1])
     #expect(middleTuple != nil, "Second element should be a Tuple")
     #expect(middleTuple?.count == 2, "Middle tuple should have 2 elements")
 
-    let bottomString = decoded[2] as? String
+    let bottomString = String.fromTuple(element: decoded[2])
     #expect(bottomString == "bottom", "Third element should be 'bottom'")
 }
 
@@ -426,8 +414,8 @@ func tupleFloatZeroInequality() throws {
     // where 0.0 == -0.0 is true.
     #expect(tuple1 != tuple2, "Positive and negative zero have different encodings")
 
-    // Verify they hash differently (important for Set/Dictionary correctness)
-    #expect(tuple1.hashValue != tuple2.hashValue, "Different values must have potentially different hashes")
+    // It is okay that they have the same hash.
+    #expect(tuple1.hashValue == tuple2.hashValue, "Different values can still have the same hashes")
 }
 
 @Test("Tuple equality - Double positive and negative zero are unequal")
@@ -436,7 +424,7 @@ func tupleDoubleZeroInequality() throws {
     let tuple2 = Tuple(Double(-0.0))
 
     #expect(tuple1 != tuple2, "Positive and negative zero have different encodings")
-    #expect(tuple1.hashValue != tuple2.hashValue, "Different values must have potentially different hashes")
+    #expect(tuple1.hashValue == tuple2.hashValue, "Different values can still have the same hashes")
 }
 
 @Test("Tuple equality - Float NaN values are equal")
@@ -504,8 +492,8 @@ func tupleEmptySet() throws {
 
 @Test("Tuple with nil values")
 func tupleWithNil() throws {
-    let tuple1 = Tuple(TupleNil(), "hello", TupleNil())
-    let tuple2 = Tuple(TupleNil(), "hello", TupleNil())
+    let tuple1 = Tuple(TupleElement.null, "hello", TupleElement.null)
+    let tuple2 = Tuple(TupleElement.null, "hello", TupleElement.null)
 
     #expect(tuple1 == tuple2, "Tuples with nil values should be equal")
     #expect(tuple1.hashValue == tuple2.hashValue, "Tuples with nil values should have same hash")
@@ -514,8 +502,8 @@ func tupleWithNil() throws {
 
 @Test("Tuple equality - nil values in different positions are unequal")
 func tupleNilPositions() throws {
-    let tuple1 = Tuple(TupleNil(), "hello")
-    let tuple2 = Tuple("hello", TupleNil())
+    let tuple1 = Tuple(TupleElement.null, "hello")
+    let tuple2 = Tuple("hello", TupleElement.null)
 
     #expect(tuple1 != tuple2, "Tuples with nils in different positions should be unequal")
 }

--- a/Tests/FoundationDBTests/FoundationDBTupleTests.swift
+++ b/Tests/FoundationDBTests/FoundationDBTupleTests.swift
@@ -507,3 +507,14 @@ func tupleNilPositions() throws {
 
     #expect(tuple1 != tuple2, "Tuples with nils in different positions should be unequal")
 }
+
+@Test("Tuple to Swift Tuple")
+func tupleToTuple() throws {
+    let tuple = Tuple("hello", 2, "foo")
+
+    let encoded = tuple.encode()
+    let (decodedString1, decodedInt, decodedString2) = try decodeTuple<String, Int, String>(from: encoded)
+    #expect(decodedString1 == "hello")
+    #expect(decodedInt == 2)
+    #expect(decodedString2 == "foo")
+}

--- a/Tests/FoundationDBTests/StringIncrementTests.swift
+++ b/Tests/FoundationDBTests/StringIncrementTests.swift
@@ -1,0 +1,184 @@
+/*
+ * StringIncrementTests.swift
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2016-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+@testable import FoundationDB
+
+@Suite("String Increment (strinc) Tests")
+struct StringIncrementTests {
+
+    // MARK: - Basic strinc() Tests
+
+    @Test("strinc increments normal byte array")
+    func strincNormal() throws {
+        let input: FDB.Bytes = [0x01, 0x02, 0x03]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x01, 0x02, 0x04])
+    }
+
+    @Test("strinc increments single byte")
+    func strincSingleByte() throws {
+        let input: FDB.Bytes = [0x42]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x43])
+    }
+
+    @Test("strinc strips trailing 0xFF and increments")
+    func strincWithTrailing0xFF() throws {
+        let input: FDB.Bytes = [0x01, 0x02, 0xFF]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x01, 0x03])
+    }
+
+    @Test("strinc strips multiple trailing 0xFF bytes")
+    func strincWithMultipleTrailing0xFF() throws {
+        let input: FDB.Bytes = [0x01, 0xFF, 0xFF]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x02])
+    }
+
+    @Test("strinc handles complex case")
+    func strincComplex() throws {
+        let input: FDB.Bytes = [0x01, 0x02, 0xFF, 0xFF, 0xFF]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x01, 0x03])
+    }
+
+    @Test("strinc handles 0xFE correctly")
+    func strinc0xFE() throws {
+        let input: FDB.Bytes = [0x01, 0xFE]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x01, 0xFF])
+    }
+
+    @Test("strinc handles overflow to 0xFF")
+    func strincOverflowTo0xFF() throws {
+        let input: FDB.Bytes = [0x00, 0xFE]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x00, 0xFF])
+    }
+
+    // MARK: - Error Cases
+
+    @Test("strinc throws error on all 0xFF bytes")
+    func strincAllFF() {
+        let input: FDB.Bytes = [0xFF, 0xFF]
+
+        do {
+            _ = try FDB.strinc(input)
+            Issue.record("Should throw error for all-0xFF input")
+        } catch let error as SubspaceError {
+            #expect(error.code == .cannotIncrementKey)
+            #expect(error.message.contains("0xFF"))
+        } catch {
+            Issue.record("Wrong error type: \(error)")
+        }
+    }
+
+    @Test("strinc throws error on empty array")
+    func strincEmpty() {
+        let input: FDB.Bytes = []
+
+        do {
+            _ = try FDB.strinc(input)
+            Issue.record("Should throw error for empty input")
+        } catch let error as SubspaceError {
+            #expect(error.code == .cannotIncrementKey)
+            #expect(error.message.contains("0xFF"))
+        } catch {
+            Issue.record("Wrong error type: \(error)")
+        }
+    }
+
+    @Test("strinc throws error on single 0xFF")
+    func strincSingle0xFF() {
+        let input: FDB.Bytes = [0xFF]
+
+        do {
+            _ = try FDB.strinc(input)
+            Issue.record("Should throw error for single 0xFF")
+        } catch let error as SubspaceError {
+            #expect(error.code == .cannotIncrementKey)
+        } catch {
+            Issue.record("Wrong error type: \(error)")
+        }
+    }
+
+    // MARK: - Cross-Reference with Official Implementations
+
+    @Test("strinc matches Java ByteArrayUtil.strinc behavior")
+    func strincJavaCompatibility() throws {
+        // Test cases from Java implementation
+        let testCases: [(input: FDB.Bytes, expected: FDB.Bytes)] = [
+            ([0x01], [0x02]),
+            ([0x01, 0x02], [0x01, 0x03]),
+            ([0x01, 0xFF], [0x02]),
+            ([0xFE], [0xFF]),
+            ([0x00, 0xFF], [0x01]),
+            ([0x01, 0x02, 0xFF, 0xFF], [0x01, 0x03])
+        ]
+
+        for (input, expected) in testCases {
+            let result = try FDB.strinc(input)
+            #expect(result == expected,
+                   "strinc(\(input.map { String(format: "%02x", $0) }.joined(separator: " "))) should equal \(expected.map { String(format: "%02x", $0) }.joined(separator: " "))")
+        }
+    }
+
+    @Test("strinc matches Go fdb.Strinc behavior")
+    func strincGoCompatibility() throws {
+        // Test cases from Go implementation
+        let testCases: [(input: FDB.Bytes, expected: FDB.Bytes)] = [
+            ([0x01, 0x00], [0x01, 0x01]),
+            ([0x01, 0x00, 0xFF], [0x01, 0x01]),
+            ([0xFE, 0xFF, 0xFF], [0xFF])
+        ]
+
+        for (input, expected) in testCases {
+            let result = try FDB.strinc(input)
+            #expect(result == expected)
+        }
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("strinc handles byte overflow correctly")
+    func strincByteOverflow() throws {
+        // When incrementing 0xFF, it wraps to 0x00 (via &+ operator)
+        // But since we increment the LAST non-0xFF byte, this should work
+        let input: FDB.Bytes = [0x01, 0xFF, 0xFF]
+        let result = try FDB.strinc(input)
+        #expect(result == [0x02])
+    }
+
+    @Test("strinc preserves leading bytes")
+    func strincPreservesLeading() throws {
+        let input: FDB.Bytes = [0xAA, 0xBB, 0xCC, 0xFF, 0xFF]
+        let result = try FDB.strinc(input)
+        #expect(result == [0xAA, 0xBB, 0xCD])
+    }
+
+    @Test("strinc works with maximum non-0xFF value")
+    func strincMaxNon0xFF() throws {
+        let input: FDB.Bytes = [0xFE]
+        let result = try FDB.strinc(input)
+        #expect(result == [0xFF])
+    }
+}

--- a/Tests/FoundationDBTests/SubspaceTests.swift
+++ b/Tests/FoundationDBTests/SubspaceTests.swift
@@ -1,0 +1,304 @@
+/*
+ * SubspaceTests.swift
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2016-2025 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Testing
+@testable import FoundationDB
+
+@Suite("Subspace Tests")
+struct SubspaceTests {
+    @Test("Subspace creation creates non-empty prefix")
+    func subspaceCreation() {
+        let subspace = Subspace(prefix: Tuple("test").encode())
+        #expect(!subspace.prefix.isEmpty)
+    }
+
+    @Test("Nested subspace prefix includes root prefix")
+    func nestedSubspace() {
+        let root = Subspace(prefix: Tuple("test").encode())
+        let nested = root.subspace(Int64(1), "child")
+
+        #expect(nested.prefix.starts(with: root.prefix))
+        #expect(nested.prefix.count > root.prefix.count)
+    }
+
+    @Test("Encode/decode preserves subspace prefix")
+    func encodeDecode() throws {
+        let subspace = Subspace(prefix: Tuple("test").encode())
+        let tuple = Tuple("key", Int64(123))
+
+        let encoded = subspace.encode(tuple)
+        _ = try subspace.decode(encoded)
+
+        // Verify the encoded key has the subspace prefix
+        #expect(encoded.starts(with: subspace.prefix))
+    }
+
+    @Test("Range returns correct begin and end keys")
+    func range() {
+        let subspace = Subspace(prefix: Tuple("test").encode())
+        let (begin, end) = subspace.range()
+
+        // Begin should be prefix + 0x00
+        #expect(begin == subspace.prefix + [0x00])
+
+        // End should be prefix + 0xFF
+        #expect(end == subspace.prefix + [0xFF])
+
+        // Verify range is non-empty (begin < end)
+        #expect(begin.lexicographicallyPrecedes(end))
+    }
+
+    @Test("Range handles 0xFF suffix correctly")
+    func rangeWithTrailing0xFF() {
+        let subspace = Subspace(prefix: [0x01, 0xFF])
+        let (begin, end) = subspace.range()
+
+        // Correct: append 0x00 and 0xFF
+        #expect(begin == [0x01, 0xFF, 0x00])
+        #expect(end == [0x01, 0xFF, 0xFF])
+
+        // Verify that a key like [0x01, 0xFF, 0x01] is within the range
+        let testKey: FDB.Bytes = [0x01, 0xFF, 0x01]
+        #expect(!testKey.lexicographicallyPrecedes(begin))  // testKey >= begin
+        #expect(testKey.lexicographicallyPrecedes(end))      // testKey < end
+    }
+
+    @Test("Range handles multiple trailing 0xFF bytes")
+    func rangeWithMultipleTrailing0xFF() {
+        let subspace = Subspace(prefix: [0x01, 0x02, 0xFF, 0xFF])
+        let (begin, end) = subspace.range()
+
+        // Correct: append 0x00 and 0xFF
+        #expect(begin == [0x01, 0x02, 0xFF, 0xFF, 0x00])
+        #expect(end == [0x01, 0x02, 0xFF, 0xFF, 0xFF])
+    }
+
+    @Test("Range handles all-0xFF prefix")
+    func rangeWithAll0xFF() {
+        let subspace = Subspace(prefix: [0xFF, 0xFF])
+        let (begin, end) = subspace.range()
+
+        // Correct: append 0x00 and 0xFF even for all-0xFF prefix
+        #expect(begin == [0xFF, 0xFF, 0x00])
+        #expect(end == [0xFF, 0xFF, 0xFF])
+
+        // Verify range is valid (begin < end)
+        #expect(begin.lexicographicallyPrecedes(end))
+    }
+
+    @Test("Range handles single 0xFF prefix")
+    func rangeWithSingle0xFF() {
+        let subspace = Subspace(prefix: [0xFF])
+        let (begin, end) = subspace.range()
+
+        // Note: [0xFF] is the start of system key space
+        // but range() still follows the pattern
+        #expect(begin == [0xFF, 0x00])
+        #expect(end == [0xFF, 0xFF])
+
+        // Verify range is valid
+        #expect(begin.lexicographicallyPrecedes(end))
+    }
+
+    @Test("Range handles special characters")
+    func rangeSpecialCharacters() {
+        let subspace = Subspace(prefix: Tuple("test_special_chars").encode())
+        let (begin, end) = subspace.range()
+
+        // begin should be prefix + [0x00]
+        #expect(begin == subspace.prefix + [0x00])
+        // end should be prefix + [0xFF]
+        #expect(end == subspace.prefix + [0xFF])
+        #expect(end != begin)
+        #expect(end.count > 0)
+    }
+
+    @Test("Range handles empty string root prefix")
+    func rangeEmptyStringPrefix() {
+        // Empty string encodes to [0x02, 0x00] in tuple encoding
+        let subspace = Subspace(prefix: Tuple("").encode())
+        let (begin, end) = subspace.range()
+
+        // Prefix should be tuple-encoded empty string
+        let encodedEmpty = Tuple("").encode()
+        #expect(begin == encodedEmpty + [0x00])
+        #expect(end == encodedEmpty + [0xFF])
+    }
+
+    @Test("Range handles truly empty prefix")
+    func rangeTrulyEmptyPrefix() {
+        // Directly construct subspace with empty byte array
+        let subspace = Subspace(prefix: [])
+        let (begin, end) = subspace.range()
+
+        // Should cover all user key space
+        #expect(begin == [0x00])
+        #expect(end == [0xFF])
+    }
+
+    @Test("Contains checks if key belongs to subspace")
+    func contains() {
+        let subspace = Subspace(prefix: Tuple("test").encode())
+        let tuple = Tuple("key")
+        let key = subspace.encode(tuple)
+
+        #expect(subspace.contains(key))
+
+        let otherSubspace = Subspace(prefix: Tuple("other").encode())
+        #expect(!otherSubspace.contains(key))
+    }
+
+    // MARK: - prefixRange() Tests
+
+    @Test("prefixRange returns prefix and strinc as bounds")
+    func prefixRange() throws {
+        let subspace = Subspace(prefix: [0x01, 0x02])
+        let (begin, end) = try subspace.prefixRange()
+
+        // Begin should be the prefix itself
+        #expect(begin == [0x01, 0x02])
+
+        // End should be strinc(prefix) = [0x01, 0x03]
+        #expect(end == [0x01, 0x03])
+    }
+
+    @Test("prefixRange handles trailing 0xFF correctly")
+    func prefixRangeWithTrailing0xFF() throws {
+        let subspace = Subspace(prefix: [0x01, 0xFF])
+        let (begin, end) = try subspace.prefixRange()
+
+        // Begin is the prefix
+        #expect(begin == [0x01, 0xFF])
+
+        // End should be strinc([0x01, 0xFF]) = [0x02]
+        #expect(end == [0x02])
+
+        // Verify that keys like [0x01, 0xFF, 0xFF, 0x00] are included
+        let testKey: FDB.Bytes = [0x01, 0xFF, 0xFF, 0x00]
+        #expect(!testKey.lexicographicallyPrecedes(begin))  // testKey >= begin
+        #expect(testKey.lexicographicallyPrecedes(end))      // testKey < end
+    }
+
+    @Test("prefixRange handles multiple trailing 0xFF bytes")
+    func prefixRangeWithMultipleTrailing0xFF() throws {
+        let subspace = Subspace(prefix: [0x01, 0x02, 0xFF, 0xFF])
+        let (begin, end) = try subspace.prefixRange()
+
+        #expect(begin == [0x01, 0x02, 0xFF, 0xFF])
+        #expect(end == [0x01, 0x03])  // strinc strips trailing 0xFF and increments
+    }
+
+    @Test("prefixRange throws error for all-0xFF prefix")
+    func prefixRangeWithAll0xFF() {
+        let subspace = Subspace(prefix: [0xFF, 0xFF])
+
+        do {
+            _ = try subspace.prefixRange()
+            Issue.record("Should throw error for all-0xFF prefix")
+        } catch let error as SubspaceError {
+            #expect(error.code == .cannotIncrementKey)
+        } catch {
+            Issue.record("Wrong error type: \(error)")
+        }
+    }
+
+    @Test("prefixRange throws error for empty prefix")
+    func prefixRangeWithEmptyPrefix() {
+        let subspace = Subspace(prefix: [])
+
+        do {
+            _ = try subspace.prefixRange()
+            Issue.record("Should throw error for empty prefix")
+        } catch let error as SubspaceError {
+            #expect(error.code == .cannotIncrementKey)
+        } catch {
+            Issue.record("Wrong error type: \(error)")
+        }
+    }
+
+    @Test("prefixRange vs range comparison for raw binary prefix")
+    func prefixRangeVsRangeComparison() throws {
+        // Raw binary prefix ending in 0xFF
+        let subspace = Subspace(prefix: [0x01, 0xFF])
+
+        // range() uses prefix + [0x00] / prefix + [0xFF]
+        let (rangeBegin, rangeEnd) = subspace.range()
+        #expect(rangeBegin == [0x01, 0xFF, 0x00])
+        #expect(rangeEnd == [0x01, 0xFF, 0xFF])
+
+        // prefixRange() uses prefix / strinc(prefix)
+        let (prefixBegin, prefixEnd) = try subspace.prefixRange()
+        #expect(prefixBegin == [0x01, 0xFF])
+        #expect(prefixEnd == [0x02])
+
+        // Keys that are included in prefixRange but NOT in range
+        let excludedByRange: FDB.Bytes = [0x01, 0xFF, 0xFF, 0x00]
+
+        // Not in range() - excluded because >= rangeEnd
+        #expect(!excludedByRange.lexicographicallyPrecedes(rangeEnd))
+
+        // But IS in prefixRange() - included because < prefixEnd
+        #expect(!excludedByRange.lexicographicallyPrecedes(prefixBegin))  // >= begin
+        #expect(excludedByRange.lexicographicallyPrecedes(prefixEnd))     // < end
+    }
+
+    @Test("prefixRange includes the prefix itself as a key")
+    func prefixRangeIncludesPrefix() throws {
+        let subspace = Subspace(prefix: [0x01, 0x02])
+        let (begin, end) = try subspace.prefixRange()
+
+        // The prefix itself is included (begin is inclusive)
+        let prefixKey = subspace.prefix
+        #expect(!prefixKey.lexicographicallyPrecedes(begin))  // >= begin
+        #expect(prefixKey.lexicographicallyPrecedes(end))      // < end
+    }
+
+    @Test("prefixRange works with single byte prefix")
+    func prefixRangeSingleByte() throws {
+        let subspace = Subspace(prefix: [0x42])
+        let (begin, end) = try subspace.prefixRange()
+
+        #expect(begin == [0x42])
+        #expect(end == [0x43])
+    }
+
+    @Test("prefixRange works with 0xFE prefix")
+    func prefixRange0xFE() throws {
+        let subspace = Subspace(prefix: [0xFE])
+        let (begin, end) = try subspace.prefixRange()
+
+        #expect(begin == [0xFE])
+        #expect(end == [0xFF])
+    }
+
+    @Test("prefixRange for tuple-encoded data")
+    func prefixRangeTupleEncoded() throws {
+        // Tuple-encoded prefix (no trailing 0xFF possible)
+        let subspace = Subspace(prefix: Tuple("users").encode())
+        let (begin, end) = try subspace.prefixRange()
+
+        // Begin is the tuple-encoded prefix
+        #expect(begin == subspace.prefix)
+
+        // End is strinc(prefix) - should work fine
+        #expect(end.count >= begin.count)  // Could be shorter or equal length
+        #expect(!end.lexicographicallyPrecedes(begin))  // end >= begin
+    }
+}

--- a/Tests/FoundationDBTests/VersionstampTests.swift
+++ b/Tests/FoundationDBTests/VersionstampTests.swift
@@ -132,7 +132,8 @@ struct VersionstampTests {
     @Test("Versionstamp encodeTuple")
     func testEncodeTuple() {
         let vs = Versionstamp.incomplete(userVersion: 0)
-        let encoded = vs.encodeTuple()
+        var encoded = FDB.Bytes()
+        vs.encodeTuple(into: &encoded)
 
         #expect(encoded.count == 13)  // 1 byte type code + 12 bytes versionstamp
         #expect(encoded[0] == 0x33)  // TupleTypeCode.versionstamp
@@ -142,7 +143,8 @@ struct VersionstampTests {
     @Test("Versionstamp decodeTuple")
     func testDecodeTuple() throws {
         let vs = Versionstamp.incomplete(userVersion: 42)
-        let encoded = vs.encodeTuple()
+        var encoded = FDB.Bytes()
+        vs.encodeTuple(into: &encoded)
 
         var offset = 1  // Skip type code
         let decoded = try Versionstamp.decodeTuple(from: encoded, at: &offset)

--- a/Tests/FoundationDBTests/VersionstampTests.swift
+++ b/Tests/FoundationDBTests/VersionstampTests.swift
@@ -147,7 +147,7 @@ struct VersionstampTests {
         vs.encodeTuple(into: &encoded)
 
         var offset = 1  // Skip type code
-        let decoded = try Versionstamp.decodeTuple(from: encoded, at: &offset)
+        let decoded = try Versionstamp.decodeTuple(from: encoded, at: &offset, typeCode: encoded[0])
 
         #expect(decoded == vs)
         #expect(offset == 13)

--- a/Tests/FoundationDBTests/VersionstampTests.swift
+++ b/Tests/FoundationDBTests/VersionstampTests.swift
@@ -1,0 +1,438 @@
+/*
+ * VersionstampTests.swift
+ *
+ * This source file is part of the FoundationDB open source project
+ *
+ * Copyright 2016-2026 Apple Inc. and the FoundationDB project authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import Testing
+@testable import FoundationDB
+
+@Suite("Versionstamp Tests")
+struct VersionstampTests {
+
+    // MARK: - Basic Versionstamp Tests
+
+    @Test("Versionstamp incomplete creation")
+    func testIncompleteCreation() {
+        let vs = Versionstamp.incomplete(userVersion: 0)
+
+        #expect(!vs.isComplete)
+        #expect(vs.userVersion == 0)
+
+        let bytes = vs.toBytes()
+        #expect(bytes.count == 12)
+        #expect(bytes.prefix(10).allSatisfy { $0 == 0xFF })
+    }
+
+    @Test("Versionstamp incomplete with user version")
+    func testIncompleteWithUserVersion() {
+        let vs = Versionstamp.incomplete(userVersion: 42)
+
+        #expect(!vs.isComplete)
+        #expect(vs.userVersion == 42)
+
+        let bytes = vs.toBytes()
+        #expect(bytes.count == 12)
+        #expect(bytes.prefix(10).allSatisfy { $0 == 0xFF })
+
+        // User version is big-endian
+        #expect(bytes[10] == 0x00)
+        #expect(bytes[11] == 0x2A)  // 42 in hex
+    }
+
+    @Test("Versionstamp complete creation")
+    func testCompleteCreation() {
+        let trVersion: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A]
+        let vs = Versionstamp(transactionVersion: trVersion, userVersion: 100)
+
+        #expect(vs.isComplete)
+        #expect(vs.userVersion == 100)
+
+        let bytes = vs.toBytes()
+        #expect(bytes.count == 12)
+        #expect(Array(bytes.prefix(10)) == trVersion)
+    }
+
+    @Test("Versionstamp fromBytes incomplete")
+    func testFromBytesIncomplete() throws {
+        let bytes: FDB.Bytes = [
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,  // incomplete
+            0x00, 0x10  // userVersion = 16
+        ]
+
+        let vs = try Versionstamp.fromBytes(bytes)
+
+        #expect(!vs.isComplete)
+        #expect(vs.userVersion == 16)
+    }
+
+    @Test("Versionstamp fromBytes complete")
+    func testFromBytesComplete() throws {
+        let bytes: FDB.Bytes = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,  // complete
+            0x00, 0x20  // userVersion = 32
+        ]
+
+        let vs = try Versionstamp.fromBytes(bytes)
+
+        #expect(vs.isComplete)
+        #expect(vs.userVersion == 32)
+        #expect(vs.transactionVersion == [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A])
+    }
+
+    @Test("Versionstamp equality")
+    func testEquality() {
+        let vs1 = Versionstamp.incomplete(userVersion: 10)
+        let vs2 = Versionstamp.incomplete(userVersion: 10)
+        let vs3 = Versionstamp.incomplete(userVersion: 20)
+
+        #expect(vs1 == vs2)
+        #expect(vs1 != vs3)
+    }
+
+    @Test("Versionstamp hashable")
+    func testHashable() {
+        let vs1 = Versionstamp.incomplete(userVersion: 5)
+        let vs2 = Versionstamp.incomplete(userVersion: 5)
+
+        var set: Set<Versionstamp> = []
+        set.insert(vs1)
+        set.insert(vs2)
+
+        #expect(set.count == 1)
+    }
+
+    @Test("Versionstamp description")
+    func testDescription() {
+        let incompleteVs = Versionstamp.incomplete(userVersion: 100)
+        #expect(incompleteVs.description.contains("incomplete"))
+
+        let trVersion: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A]
+        let completeVs = Versionstamp(transactionVersion: trVersion, userVersion: 200)
+        #expect(completeVs.description.contains("0102030405060708090a"))
+    }
+
+    // MARK: - TupleElement Tests
+
+    @Test("Versionstamp encodeTuple")
+    func testEncodeTuple() {
+        let vs = Versionstamp.incomplete(userVersion: 0)
+        let encoded = vs.encodeTuple()
+
+        #expect(encoded.count == 13)  // 1 byte type code + 12 bytes versionstamp
+        #expect(encoded[0] == 0x33)  // TupleTypeCode.versionstamp
+        #expect(encoded.suffix(12) == vs.toBytes())
+    }
+
+    @Test("Versionstamp decodeTuple")
+    func testDecodeTuple() throws {
+        let vs = Versionstamp.incomplete(userVersion: 42)
+        let encoded = vs.encodeTuple()
+
+        var offset = 1  // Skip type code
+        let decoded = try Versionstamp.decodeTuple(from: encoded, at: &offset)
+
+        #expect(decoded == vs)
+        #expect(offset == 13)
+    }
+
+    // MARK: - Tuple.encodeWithVersionstamp() Tests
+
+    @Test("Tuple encodeWithVersionstamp basic")
+    func testPackWithVersionstampBasic() throws {
+        let vs = Versionstamp.incomplete(userVersion: 0)
+        let tuple = Tuple("prefix", vs)
+
+        let packed = try tuple.encodeWithVersionstamp()
+
+        // Verify structure:
+        // - String "prefix" encoded
+        // - Versionstamp 0x33 + 12 bytes
+        // - 4-byte offset (little-endian)
+        #expect(packed.count > 13 + 4)
+
+        // Last 4 bytes should be the offset
+        #expect(packed.count >= 4, "Packed data must have at least 4 bytes for offset")
+        let offsetBytes = Array(packed.suffix(4))
+        #expect(offsetBytes.count == 4, "Offset must be exactly 4 bytes")
+
+        let offset = offsetBytes.withUnsafeBytes { $0.load(as: UInt32.self).littleEndian }
+
+        // Offset should point to the start of the 10-byte transaction version
+        // (after type code 0x33)
+        #expect(offset > 0)
+        #expect(Int(offset) < packed.count - 4)
+    }
+
+    @Test("Tuple encodeWithVersionstamp with prefix")
+    func testPackWithVersionstampWithPrefix() throws {
+        let vs = Versionstamp.incomplete(userVersion: 0)
+        let tuple = Tuple(vs)
+        let prefix: FDB.Bytes = [0x01, 0x02, 0x03]
+
+        let packed = try tuple.encodeWithVersionstamp(prefix: prefix)
+
+        // Verify prefix is prepended
+        #expect(Array(packed.prefix(3)) == prefix)
+
+        // Last 4 bytes should be the offset
+        #expect(packed.count >= 4, "Packed data must have at least 4 bytes for offset")
+        let offsetBytes = Array(packed.suffix(4))
+        #expect(offsetBytes.count == 4, "Offset must be exactly 4 bytes")
+
+        let offset = offsetBytes.withUnsafeBytes { $0.load(as: UInt32.self).littleEndian }
+
+        // Offset should account for prefix length
+        #expect(offset == 3 + 1)  // prefix (3) + type code (1)
+    }
+
+    @Test("Tuple encodeWithVersionstamp no incomplete error")
+    func testPackWithVersionstampNoIncomplete() {
+        let trVersion: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A]
+        let completeVs = Versionstamp(transactionVersion: trVersion, userVersion: 0)
+        let tuple = Tuple("prefix", completeVs)
+
+        do {
+            _ = try tuple.encodeWithVersionstamp()
+            Issue.record("Should throw error when no incomplete versionstamp")
+        } catch {
+            #expect(error is TupleError)
+        }
+    }
+
+    @Test("Tuple encodeWithVersionstamp multiple incomplete error")
+    func testPackWithVersionstampMultipleIncomplete() {
+        let vs1 = Versionstamp.incomplete(userVersion: 0)
+        let vs2 = Versionstamp.incomplete(userVersion: 1)
+        let tuple = Tuple("prefix", vs1, vs2)
+
+        do {
+            _ = try tuple.encodeWithVersionstamp()
+            Issue.record("Should throw error when multiple incomplete versionstamps")
+        } catch {
+            #expect(error is TupleError)
+        }
+    }
+
+    @Test("Tuple hasIncompleteVersionstamp")
+    func testHasIncompleteVersionstamp() {
+        let incompleteVs = Versionstamp.incomplete(userVersion: 0)
+        let tuple1 = Tuple("test", incompleteVs)
+        #expect(tuple1.hasIncompleteVersionstamp())
+
+        let trVersion: [UInt8] = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A]
+        let completeVs = Versionstamp(transactionVersion: trVersion, userVersion: 0)
+        let tuple2 = Tuple("test", completeVs)
+        #expect(!tuple2.hasIncompleteVersionstamp())
+
+        let tuple3 = Tuple("test", "no versionstamp")
+        #expect(!tuple3.hasIncompleteVersionstamp())
+    }
+
+    @Test("Tuple countIncompleteVersionstamps")
+    func testCountIncompleteVersionstamps() {
+        let vs1 = Versionstamp.incomplete(userVersion: 0)
+        let vs2 = Versionstamp.incomplete(userVersion: 1)
+
+        let tuple1 = Tuple(vs1)
+        #expect(tuple1.countIncompleteVersionstamps() == 1)
+
+        let tuple2 = Tuple(vs1, "middle", vs2)
+        #expect(tuple2.countIncompleteVersionstamps() == 2)
+
+        let tuple3 = Tuple("no versionstamp")
+        #expect(tuple3.countIncompleteVersionstamps() == 0)
+    }
+
+    @Test("Tuple validateForVersionstamp")
+    func testValidateForVersionstamp() throws {
+        let vs = Versionstamp.incomplete(userVersion: 0)
+        let tuple1 = Tuple(vs)
+        try tuple1.validateForVersionstamp()  // Should not throw
+
+        let tuple2 = Tuple("no versionstamp")
+        do {
+            try tuple2.validateForVersionstamp()
+            Issue.record("Should throw when no versionstamp")
+        } catch {
+            #expect(error is TupleError)
+        }
+
+        let vs2 = Versionstamp.incomplete(userVersion: 1)
+        let tuple3 = Tuple(vs, vs2)
+        do {
+            try tuple3.validateForVersionstamp()
+            Issue.record("Should throw when multiple versionstamps")
+        } catch {
+            #expect(error is TupleError)
+        }
+    }
+
+    // MARK: - Roundtrip Tests (Encode → Decode)
+
+    @Test("Versionstamp roundtrip with complete versionstamp")
+    func testVersionstampRoundtripComplete() throws {
+        let original = Versionstamp(
+            transactionVersion: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A],
+            userVersion: 42
+        )
+        let tuple = Tuple("prefix", original, "suffix")
+
+        // Encode
+        let encoded = tuple.encode()
+
+        // Decode through Tuple.decode()
+        let decoded = try Tuple.decode(from: encoded)
+
+        #expect(decoded.count == 3)
+        #expect(String.fromTuple(element: decoded[0]) == "prefix")
+        #expect(Versionstamp.fromTuple(element: decoded[1]) == original)
+        #expect(String.fromTuple(element: decoded[2]) == "suffix")
+    }
+
+    @Test("Versionstamp roundtrip with incomplete versionstamp")
+    func testVersionstampRoundtripIncomplete() throws {
+        let original = Versionstamp.incomplete(userVersion: 123)
+        let tuple = Tuple(original)
+
+        // Encode
+        let encoded = tuple.encode()
+
+        // Decode
+        let decoded = try Tuple.decode(from: encoded)
+
+        #expect(decoded.count == 1)
+        let decodedVS = Versionstamp.fromTuple(element: decoded[0])
+        #expect(decodedVS == original)
+        #expect(decodedVS?.isComplete == false)
+        #expect(decodedVS?.userVersion == 123)
+    }
+
+    @Test("Versionstamp roundtrip mixed tuple")
+    func testVersionstampRoundtripMixed() throws {
+        let vs = Versionstamp(
+            transactionVersion: [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA, 0x99, 0x88, 0x77, 0x66],
+            userVersion: 999
+        )
+        let tuple = Tuple(
+            "string",
+            Int64(12345),
+            vs,
+            true,
+            [UInt8]([0x01, 0x02, 0x03])
+        )
+
+        let encoded = tuple.encode()
+        let decoded = try Tuple.decode(from: encoded)
+
+        #expect(decoded.count == 5)
+        #expect(String.fromTuple(element: decoded[0]) == "string")
+        #expect(Int64.fromTuple(element: decoded[1]) == 12345)
+        #expect(Versionstamp.fromTuple(element: decoded[2]) == vs)
+        #expect(Bool.fromTuple(element: decoded[3]) == true)
+        #expect(FDB.Bytes.fromTuple(element: decoded[4]) == [0x01, 0x02, 0x03])
+    }
+
+    @Test("Decode versionstamp with insufficient bytes throws error")
+    func testDecodeVersionstampInsufficientBytes() {
+        let encoded: FDB.Bytes = [
+            TupleTypeCode.versionstamp.rawValue,
+            0x01, 0x02, 0x03  // Need 12 bytes but only 3
+        ]
+
+        do {
+            _ = try Tuple.decode(from: encoded)
+            Issue.record("Should throw error for insufficient bytes")
+        } catch {
+            // Expected - should throw TupleError.invalidEncoding
+            #expect(error is TupleError)
+        }
+    }
+
+    @Test("Multiple versionstamps roundtrip")
+    func testMultipleVersionstampsRoundtrip() throws {
+        let vs1 = Versionstamp.incomplete(userVersion: 1)
+        let vs2 = Versionstamp(
+            transactionVersion: [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A],
+            userVersion: 2
+        )
+        let tuple = Tuple(vs1, "middle", vs2)
+
+        let encoded = tuple.encode()
+        let decoded = try Tuple.decode(from: encoded)
+
+        #expect(decoded.count == 3)
+        #expect(Versionstamp.fromTuple(element: decoded[0]) == vs1)
+        #expect(String.fromTuple(element: decoded[1]) == "middle")
+        #expect(Versionstamp.fromTuple(element: decoded[2]) == vs2)
+    }
+
+    @Test("Integration: Write and read versionstamped key")
+    func testIntegrationWriteReadVersionstampedKey() async throws {
+        try await FDBClient.maybeInitialize()
+        let database = try FDBClient.openDatabase()
+
+        let beginKey = Tuple("test_prefix").encode()
+        let endKey = Tuple("test_prefixx").encode()
+
+        // Clear test key range
+        let clearTransaction = try database.createTransaction()
+        clearTransaction.clearRange(beginKey: beginKey, endKey: endKey)
+        _ = try await clearTransaction.commit()
+
+        let vsIncomplete = Versionstamp.incomplete(userVersion: 0)
+        let tuple = Tuple("test_prefix", vsIncomplete)
+        let key = try tuple.encodeWithVersionstamp()
+
+        let transaction = try database.createTransaction()
+
+        // Write versionstamped key
+        transaction.atomicOp(
+            key: key,
+            param: [],
+            mutationType: .setVersionstampedKey
+        )
+
+        // Get committed versionstamp
+        let result = try await withThrowingTaskGroup(of: Optional<FDB.Bytes>.self) { group in
+            group.addTask { try await transaction.getVersionstamp() }
+            group.addTask {
+                try await Task.sleep(for: .milliseconds(100))
+                _ = try await transaction.commit();
+                return nil
+            }
+            let r1 = try await group.next()!
+            let r2 = try await group.next()!
+            return r1 ?? r2
+        }
+
+        // Verify versionstamp was returned
+        #expect(result != nil)
+        #expect(result!.count == 10)
+        let vsCommit = Versionstamp(transactionVersion: result!)
+
+        // Verify that matches the key that was written.
+        let readTransaction = try database.createTransaction()
+        let rangeResult = try await readTransaction.getRangeNative(beginSelector: FDB.KeySelector.firstGreaterOrEqual(beginKey),
+                                                                   endSelector: FDB.KeySelector.firstGreaterThan(endKey))
+        #expect(rangeResult.records.count == 1)
+        let readTuple = try Tuple.decode(from: rangeResult.records[0].0)
+        let vsComplete = Versionstamp.fromTuple(element: readTuple[1])
+        #expect(vsComplete == vsCommit, "versionstamp should match")
+    }
+}

--- a/Tests/StackTester/Sources/StackTester/StackTester.swift
+++ b/Tests/StackTester/Sources/StackTester/StackTester.swift
@@ -100,7 +100,7 @@ class StackMachine {
 
     // Helper method to pack range results like Python's push_range
     func pushRange(_ idx: Int, _ records: [(key: [UInt8], value: [UInt8])], prefixFilter: [UInt8]? = nil) {
-        var kvs: [any TupleElement] = []
+        var kvs: [any TupleElementConvertible] = []
         for (key, value) in records {
             if let prefix = prefixFilter {
                 if key.starts(with: prefix) {
@@ -511,7 +511,7 @@ class StackMachine {
 
         case "TUPLE_PACK":
             let numElements = waitAndPop().item as! Int64
-            var elements: [any TupleElement] = []
+            var elements: [any TupleElementConvertible] = []
 
             for _ in 0 ..< numElements {
                 let item = waitAndPop().item
@@ -535,7 +535,7 @@ class StackMachine {
             // Python order: prefix, count, items
             let prefix = waitAndPop().item as! [UInt8]
             let numElements = waitAndPop().item as! Int64
-            var elements: [any TupleElement] = []
+            var elements: [any TupleElementConvertible] = []
 
             for _ in 0 ..< numElements {
                 let item = waitAndPop().item
@@ -560,15 +560,16 @@ class StackMachine {
         case "TUPLE_UNPACK":
             let encodedTuple = waitAndPop().item as! [UInt8]
             do {
-                let elements = try Tuple.decode(from: encodedTuple)
-                for element in elements.reversed() { // Reverse to match stack order
-                    if let bytes = element as? [UInt8] {
+                let tuple = try Tuple.decode(from: encodedTuple)
+                for element in tuple.elements.reversed() { // Reverse to match stack order
+                    switch element {
+                    case let .bytes(bytes):
                         store(idx, bytes)
-                    } else if let string = element as? String {
+                    case let .string(string):
                         store(idx, Array(string.utf8))
-                    } else if let int = element as? Int64 {
+                    case let .int(int):
                         store(idx, int)
-                    } else {
+                    default:
                         store(idx, Array("UNKNOWN_TYPE".utf8))
                     }
                 }
@@ -592,7 +593,7 @@ class StackMachine {
 
         case "TUPLE_RANGE":
             let numElements = waitAndPop().item as! Int64
-            var elements: [any TupleElement] = []
+            var elements: [any TupleElementConvertible] = []
 
             for _ in 0 ..< numElements {
                 let item = waitAndPop().item
@@ -697,18 +698,19 @@ class StackMachine {
         // Process each instruction
         for (i, (_, value)) in instructions.enumerated() {
             // Unpack the instruction tuple from the value
-            let elements = try Tuple.decode(from: value)
+            let tuple = try Tuple.decode(from: value)
 
             // Convert tuple elements to array for processing
             var instruction: [Any] = []
-            for element in elements {
-                if let stringElement = element as? String {
+            for element in tuple.elements {
+                switch element {
+                case let .string(stringElement):
                     instruction.append(stringElement)
-                } else if let bytesElement = element as? [UInt8] {
+                case let .bytes(bytesElement):
                     instruction.append(bytesElement)
-                } else if let intElement = element as? Int64 {
+                case let .int(intElement):
                     instruction.append(intElement)
-                } else {
+                default:
                     instruction.append(element)
                 }
             }


### PR DESCRIPTION
Change the API and implementation for `Tuple`.

**Subscripting**

The `subscript(_:Int)` method today returns a `TupleElement?`, with `nil` coming from a `guard` for out-of-bounds.
This is like `Dictionary` and unlike `Array`, which gives a non-recoverable error for out-of-bounds.
Other `Collection`-like objects, such as rows in Postgres-NIO also behave like arrays.

This PR changes to `TupleElement`, no optional.
The caller can put in appropriate checks to avoid fatal errors, near where the data came from.

**Tuple elements**

The items in the `Tuple` `struct` are now in a public array of `TupleElement`, which is an enum with associated values for each of the type code cases.
The `enum` is marked `@nonexhaustive`, which means that `switch` on it will need to be designed to handle future types that might get added, often with some kind of error.

This seems to be, in balance, the best way to allow low-level adopters to dispatch on individual elements without burdening high-level adopters, who just want to extend and encode into key-value store keys.

The special null tuple element, which has no associated value, was previously represented by an internal class.
This was very hard to work with. It is now just another `switch case`.

**Tuple conversion**

Prior to this branch, the elements of a tuple conformed to a public protocol for conversion to and from byte arrays.
Standard Swift types, like integer and string, were extended to implement this conversion.
This meant that one could have a new conforming class as an element and it would encode properly, perhaps using some new, unknown, type code.
But there was no support in the other direction, decoding into anything other than the known element types.

This is changed to be two protocols, only one of which is public.

The `TupleElementConvertible` public protocol allows initialization of a `Tuple` from an array / varargs of the corresponding primitive types.

* A `TupleCodable` internal protocol is used for modularizing the implement as a set of encode / decode extensions on those primitive types, using much of the same code as before. It is not essential and could just as well be `switch` statements in the `encode` and `decode` methods.

Conversion is also supported in the other direction, as `static` methods in the `TupleElementConvertible` and a generic `TupleElement.convert`.
This means that any of the four following places to put the target type work equivalently (and with equal efficiency, since they call the first method):

* `let s = String.fromTuple(elem)`
* `let s: String? = elem.convert()`
* `let s = elem.convert<String>()`
* `let s = elem.convert(String.self)`

**Type safe tuples**

Conversion is also supported from Swift tuples. `Tuple.decode` can be given a tuple type; again in several different exact syntaxes.

* `let st = try Tuple.decode(from: encoded, as: (String, Int, String).self)`
* `let st: (String, Int, String) = try Tuple.decode(from: encoded)`
* `let (s1, i, s2) = try Tuple.decode<String, Int, String>(from: encoded)`

**Versionstamps**

This adds the versionstamp support from #16, with minor adjustments for the another above changes.

**Nested tuples**

This fixes nested tuple encoding to be compatible with other bindings and [the spec](https://github.com/apple/foundationdb/blob/main/design/tuple.md#nested-tuple).

Previously, all `00` bytes in the normal tuple encoding of the nested tuple were escaped with `FF`.
Now only `00`s resulting from null tuple elements are escaped. Those that were _inside_ strings and byte arrays were already ecaped.
And those that were at the end of strings and byte arrays do not want to be to give the proper lexicographical ordering.

**Subspace**

Includes subspace support taken from #16.

**Encoding / decoding naming**

This PR sticks with the Swift-leaning naming using `encode` and `decode` for conversion to / from byte arrays.
#16 had proposed to use `pack` and `unpack`, for greater compatibility with other bindings.

**Encoding efficiency**

Encoding to a byte array now pre-allocates the final byte string and does not generate intermediate byte strings for each of the elements or pieces thereof.

**Examples**

The necessary changes to the unit tests may give the best idea of the flavor of these changes.